### PR TITLE
[docs] Add a prompt quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ response = client.chat("Hello!")
 
 ### Documentation
 
-**Getting Started:** [Installation](./docs/getting-started/installation.md) | [Quick Start](./docs/getting-started/quick-start.md) | [Authentication](./docs/getting-started/authentication.md)
+**Getting Started:** [Installation](./docs/getting-started/installation.md) | [Quick Start](./docs/getting-started/quick-start.md) | [Prompt Quickstart](./docs/getting-started/prompt-quickstart.md) | [Authentication](./docs/getting-started/authentication.md)
 
 **API Reference:** [Chat Completions](./docs/api-reference/chat-completions.md) | [Models](./docs/api-reference/models.md) | [Errors](./docs/api-reference/errors.md)
 

--- a/docs/getting-started/prompt-quickstart.md
+++ b/docs/getting-started/prompt-quickstart.md
@@ -13,10 +13,10 @@ Copy and paste this into Claude Code:
 
 ```
 Set up BlockRun for x402 payments in Claude Code:
-1. Install blockrun-mcp
-2. Configure wallet (ask if I have one or want auto-generated)
-3. Help me fund it
-4. Prove it works: show balance → make an LLM call → show balance changed
+1. Install blockrun-mcp: `npx @anthropic-ai/claude-code mcp add blockrun-mcp`
+2. Configure BLOCKRUN_WALLET_KEY (ask if I have a private key or want to generate one)
+3. Show my wallet address and help me fund it with USDC on Base
+4. Prove it works: check balance → make an LLM call → confirm balance decreased
 ```
 
 Claude will walk you through each step interactively.

--- a/docs/getting-started/prompt-quickstart.md
+++ b/docs/getting-started/prompt-quickstart.md
@@ -1,0 +1,22 @@
+# Prompt Quickstart
+
+Get started with BlockRun in Claude Code using a single prompt.
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/code) installed
+- USDC on Base (or funds ready to transfer)
+
+## The Prompt
+
+Copy and paste this into Claude Code:
+
+```
+Set up BlockRun for x402 payments in Claude Code:
+1. Install blockrun-mcp
+2. Configure wallet (ask if I have one or want auto-generated)
+3. Help me fund it
+4. Prove it works: show balance → make an LLM call → show balance changed
+```
+
+Claude will walk you through each step interactively.


### PR DESCRIPTION
Add a quickstart section that uses prompting instead to setup blockrun

```
Set up BlockRun for x402 payments in Claude Code:
1. Install blockrun-mcp: `npx @anthropic-ai/claude-code mcp add blockrun-mcp`
2. Configure BLOCKRUN_WALLET_KEY (ask if I have a private key or want to generate one)
3. Show my wallet address and help me fund it with USDC on Base
4. Prove it works: check balance → make an LLM call → confirm balance decreased
```