### PR TITLE
Add TensorFeed to Community Integrations

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -55,6 +55,7 @@ BlockRun works with the x402 facilitator network:
 |---------|----------|-------------|
 | [LLM_trader](https://github.com/qrak/LLM_trader) | Trading Bot | Autonomous crypto trading bot with Visual Cortex for chart analysis |
 | [Voyage GEO](https://github.com/onvoyage-ai/voyage-geo-agent) | AI Analytics | Generative Engine Optimization - track AI brand mentions across multiple models |
+| [TensorFeed](https://tensorfeed.ai) | AI Intelligence | AI-industry intelligence for agents: vendor pricing, model status, deprecations, CVEs, capital, research. Daily-fresh JSON feeds. Premium endpoints priced in USDC via x402, cataloged in CDP Bazaar ([manifest](https://tensorfeed.ai/.well-known/x402.json), [/developers](https://tensorfeed.ai/developers)) |
 
 ### Claude Code Tools
 


### PR DESCRIPTION
Adds TensorFeed.ai to the Community Integrations section.

**What it is:** AI-industry intelligence for AI agents. Daily-fresh JSON feeds covering vendor pricing, model status + deprecations, CVEs (NVD/GHSA/KEV), capital flows, research velocity, and incident triage.

**Why it fits the BlockRun ecosystem:** Premium endpoints are priced in USDC on Base via the x402 protocol, cataloged in CDP Bazaar. Agents can discover + pay TensorFeed feeds through the same on-chain rails BlockRun agents use for everything else. 19,400+ paid calls served to date, 34 endpoints in the Bazaar pilot, 111-item x402 manifest.

**Quick links:**
- Site: https://tensorfeed.ai
- x402 manifest: https://tensorfeed.ai/.well-known/x402.json
- Developers: https://tensorfeed.ai/developers
- MCP server: https://www.npmjs.com/package/tensorfeed-mcp

Happy to adjust the wording or category if Editorial prefers a different framing.