### PR TITLE
Add LoneStarOracle -- 39 x402 AI data services on Base

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -53,6 +53,7 @@ BlockRun works with the x402 facilitator network:
 
 | Project | Category | Description |
 |---------|----------|-------------|
+| [LoneStarOracle](https://lonestaroracle.xyz) | Data Services | 39 live x402 AI data services on Base — TokenScope, RattlerAI, WeatherOracle, ChainScout, Floyd and more. MCP server at mcp.lonestaroracle.xyz |
 | [LLM_trader](https://github.com/qrak/LLM_trader) | Trading Bot | Autonomous crypto trading bot with Visual Cortex for chart analysis |
 | [Voyage GEO](https://github.com/onvoyage-ai/voyage-geo-agent) | AI Analytics | Generative Engine Optimization - track AI brand mentions across multiple models |
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Built into both Python and TypeScript SDKs. Also available as standalone: [ClawR
 | [Exa](https://exa.ai) | Web Search | Neural web search, find-similar, page contents, AI-grounded answers |
 | [Predexon](https://predexon.com) | Prediction Markets | Polymarket, Kalshi, dFlow, Binance Futures data |
 | [Modal](https://modal.com) | Sandbox Compute | Managed Python sandboxes for isolated code execution |
+| [LoneStarOracle](https://lonestaroracle.xyz) | Data Services | 39 x402-native AI data services on Base — token forensics, smart contract audits, weather consensus, on-chain intel, commodity signals. MCP at mcp.lonestaroracle.xyz |
 
 ### x402 Facilitators
 


### PR DESCRIPTION
## What this adds

[LoneStarOracle](https://lonestaroracle.xyz) is a suite of 39 live, pay-per-call AI data services built natively on the x402 protocol on Base mainnet.

**Why it belongs here:**
- Every endpoint is x402-gated (USDC on Base, no API keys required)
- MCP server at mcp.lonestaroracle.xyz (38 tools, published to official MCP registry as xyz.lonestaroracle/mcp-server v1.1.0)
- Services: TokenScope (token forensics), RattlerAI/CottonmouthAI/CopperheadAI (smart contract audits), WeatherOracle, ChainScout, Floyd (AI agent), and 32 more

Added to README.md (Data Partners) and ECOSYSTEM.md (Community Integrations).