### PR TITLE
docs: deep content — SDK client classes, MCP params, x402 EIP-712 signature

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -48,7 +48,6 @@
 
 * [Python](sdks/python.md)
 * [TypeScript](sdks/typescript.md)
-* [XRPL (Python)](sdks/xrpl.md)
 * [Go](sdks/go.md)
 
 ## API Reference

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -15,7 +15,7 @@ Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 50+ mod
 
 :::step{title="Install the plugin"}
 ```bash
-npm install elizaos-plugin-blockrun
+npm install @blockrun/elizaos-plugin
 ```
 :::
 
@@ -25,70 +25,29 @@ export BLOCKRUN_WALLET_KEY=0x...your_private_key...
 ```
 :::
 
-:::step{title="Register the provider"}
-```typescript
-import { BlockRunProvider } from 'elizaos-plugin-blockrun';
+:::step{title="Register the plugin"}
+The package exports a single `blockrunPlugin` — add it to your ElizaOS character's `plugins` array (the standard ElizaOS plugin pattern).
 
-const agent = new ElizaAgent({
-  // ... other config
-  providers: [
-    new BlockRunProvider({
-      defaultModel: 'openai/gpt-5.4',
-      sessionBudget: 10.00  // Optional: max spend per session
-    })
-  ]
-});
+```typescript
+import { blockrunPlugin } from '@blockrun/elizaos-plugin';
+
+export const character = {
+  name: 'MyAgent',
+  // ...other character config
+  plugins: [blockrunPlugin],
+};
 ```
 :::
 
 ::::
+
+Once registered, the agent uses BlockRun models through ElizaOS's normal model calls — no per-provider API keys, paid per request from the wallet key you set. The plugin's actions and providers are the source of truth; see the [repo](https://github.com/BlockRunAI/elizaos-plugin-blockrun) for the current action/provider list.
 
 ## Usage
 
-### Basic Chat
+With `blockrunPlugin` registered, your agent reaches BlockRun models through ElizaOS's normal model interface — chat, plus image/video/music when you call those actions. Model selection follows your ElizaOS character/runtime settings; BlockRun model ids look like `openai/gpt-5.5`, `anthropic/claude-opus-4.8`, `deepseek/deepseek-chat`. The plugin's exact actions and providers live in the [plugin repo](https://github.com/BlockRunAI/elizaos-plugin-blockrun) — treat it as the source of truth for action names and options.
 
-```typescript
-const response = await agent.chat({
-  model: 'openai/gpt-5.4',
-  messages: [
-    { role: 'user', content: 'Hello!' }
-  ]
-});
-```
-
-### Model Selection
-
-::::tabs
-
-:::tab{label="Premium model"}
-```typescript
-const response = await agent.chat({
-  model: 'anthropic/claude-sonnet-4.6',
-  messages: [...]
-});
-```
-:::
-
-:::tab{label="Cheap model (bulk)"}
-```typescript
-const response = await agent.chat({
-  model: 'deepseek/deepseek-chat',
-  messages: [...]
-});
-```
-:::
-
-::::
-
-### Image Generation
-
-```typescript
-const image = await agent.generateImage({
-  prompt: 'A futuristic AI agent',
-  model: 'google/nano-banana',
-  size: '1024x1024'
-});
-```
+For full media/data control (image, video, search, RPC, etc.) outside the ElizaOS model flow, call the [TypeScript SDK](../sdks/typescript.md) clients directly from your actions — same wallet, same x402 settlement.
 
 ## Available Models
 
@@ -113,107 +72,15 @@ Your agent pays per request via x402. No API keys needed for individual provider
 
 See [Intelligence Pricing](../products/intelligence/pricing.md).
 
-## Wallet Setup
+## Wallet & budgets
 
-### Create New Wallet
-
-```typescript
-import { createWallet } from 'elizaos-plugin-blockrun';
-
-const wallet = await createWallet();
-console.log('Address:', wallet.address);
-// Fund this address with USDC on Base
-```
-
-### Use Existing Wallet
+The plugin pays from one wallet — set `BLOCKRUN_WALLET_KEY`, or let BlockRun create and use a local key at `~/.blockrun/.session`. Fund it with USDC on Base (or Solana) and manage spend caps the same way as any BlockRun client.
 
 ```bash
-export BLOCKRUN_WALLET_KEY=0x...
+export BLOCKRUN_WALLET_KEY=0x...   # the wallet your agent spends from
 ```
 
-### Check Balance
-
-```typescript
-import { getBalance } from 'elizaos-plugin-blockrun';
-
-const balance = await getBalance();
-console.log(`Balance: $${balance} USDC`);
-```
-
-## Example Agent
-
-```typescript
-import { ElizaAgent } from 'elizaos';
-import { BlockRunProvider } from 'elizaos-plugin-blockrun';
-
-const agent = new ElizaAgent({
-  name: 'TradingBot',
-  description: 'An AI trading assistant',
-  providers: [
-    new BlockRunProvider({
-      defaultModel: 'openai/gpt-5.4'
-    })
-  ],
-  actions: [
-    // Your agent actions
-  ]
-});
-
-// Agent now has access to 50+ models via BlockRun
-await agent.start();
-```
-
-## Error Handling
-
-```typescript
-try {
-  const response = await agent.chat({
-    model: 'openai/gpt-5.4',
-    messages: [...]
-  });
-} catch (error) {
-  if (error.code === 'INSUFFICIENT_BALANCE') {
-    console.log('Need to fund wallet');
-  } else if (error.code === 'MODEL_NOT_FOUND') {
-    console.log('Invalid model specified');
-  } else {
-    throw error;
-  }
-}
-```
-
-## Best Practices
-
-### Cost Optimization
-
-```typescript
-// Use cheap models for routine tasks
-const cheapProvider = new BlockRunProvider({
-  defaultModel: 'deepseek/deepseek-chat'  // much cheaper than GPT-5.4
-});
-
-// Use premium models for important decisions
-const premiumProvider = new BlockRunProvider({
-  defaultModel: 'openai/gpt-5.4'
-});
-```
-
-### Session Budgets
-
-```typescript
-new BlockRunProvider({
-  sessionBudget: 5.00  // Max $5 per session
-});
-```
-
-### Fallback Models
-
-```typescript
-new BlockRunProvider({
-  defaultModel: 'openai/gpt-5.4',
-  fallbackModel: 'deepseek/deepseek-chat'  // Use if primary fails
-});
-```
+See [Wallet Setup](../getting-started/wallet-setup.md) for funding, chain switching, and per-agent budget delegation.
 
 ## Links
 

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -206,7 +206,7 @@ The MCP includes built-in smart routing that selects the best model based on you
 | `coding` | Coding-tuned models | Code generation/review |
 | `glm` | Zhipu GLM-5 / GLM-5-Turbo | Flat-rate ($0.001/call) bulk |
 
-`mode` picks a model by intent in one hop. For prompt-aware selection (the scorer reads the prompt and picks the cheapest capable model), use `routing:"smart"` with a `routing_profile` instead — see [Smart Routing](../products/intelligence/smart-routing.md).
+`mode` picks a model by intent in one hop. For prompt-aware selection (the scorer reads the prompt and picks the cheapest capable model), use `routing:"smart"` with a `routing_profile` instead — see [ClawRouter / Smart Routing](../products/routing/clawrouter.md).
 
 ## Configuration
 

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -109,9 +109,29 @@ Generate a 5-second video of a sunset over Tokyo
 Compose a 60-second lo-fi hip-hop loop
 ```
 
+**Parameters**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `message` | string | The prompt (or use `messages` for multi-turn). |
+| `model` | string | Explicit model id, e.g. `openai/gpt-5.5`. Overrides `mode`. |
+| `mode` | enum | Pick a model by intent instead of by name: `fast`, `balanced`, `powerful`, `cheap`, `reasoning`, `free`, `coding`, `glm`. |
+| `routing` | `"smart"` | Run ClawRouter's local scorer to choose the cheapest capable model. Pair with `routing_profile`. |
+| `routing_profile` | enum | `free` · `eco` · `auto` (default) · `premium`. Only used when `routing:"smart"`. |
+| `system` | string | System prompt. |
+| `max_tokens` | number | Default `1024`. |
+| `temperature` | number | Default `1`. |
+| `messages` | array | `[{role:"user"\|"assistant"\|"system", content}]` for multi-turn. |
+| `agent_id` | string | Attribute the spend to a sub-agent budget (see `blockrun_wallet`). |
+
+```
+blockrun_chat mode:"reasoning" message:"Prove there are infinitely many primes"
+blockrun_chat routing:"smart" routing_profile:"eco" message:"Summarize this thread"
+```
+
 ### `blockrun_search`
 
-Live web and news search (Grok-grounded).
+Live web and news search (Grok-grounded). Params: `query` (required), `sources` (`web` · `x` · `news`), `max_results` (1–50, default 10), `from_date` / `to_date` (`YYYY-MM-DD`).
 
 ### `blockrun_exa`
 
@@ -151,10 +171,24 @@ List all available models with live pricing, context windows, and categories.
 
 ### `blockrun_wallet`
 
-USDC balance, agent budgets, wallet setup.
+USDC balance, wallet setup, chain switching, and per-agent budget delegation.
+
+**`action`** (default `status`):
+
+| action | What it does | Extra params |
+|--------|--------------|--------------|
+| `status` | Address, USDC balance, session spend | — |
+| `setup` | Print address + funding QR (creates wallet on first run) | — |
+| `chain` | Switch active chain | `chain:"base"` \| `"solana"` |
+| `budget` | Set/clear a global session spend cap | `budget_action:"set"\|"clear"`, `budget_amount` |
+| `delegate` | Allocate a spend limit to a sub-agent | `agent_id`, `agent_limit` |
+| `revoke` | Remove a sub-agent's budget | `agent_id` |
+| `report` | Per-agent spending breakdown | — |
 
 ```
-blockrun balance
+blockrun_wallet action:"status"
+blockrun_wallet action:"budget" budget_action:"set" budget_amount:5.00
+blockrun_wallet action:"delegate" agent_id:"researcher" agent_limit:2.00
 ```
 
 ### Smart Routing
@@ -165,9 +199,14 @@ The MCP includes built-in smart routing that selects the best model based on you
 |------|--------|----------|
 | `fast` | Gemini Flash, GPT-5 Mini | Quick responses |
 | `balanced` | GPT-5.4, Claude Sonnet 4.6 | General use |
-| `powerful` | GPT-5.4, Claude Opus 4.6 | Complex tasks |
+| `powerful` | GPT-5.4, Claude Opus 4.8 | Complex tasks |
 | `cheap` | NVIDIA free models, DeepSeek, Gemini Flash | Cost savings |
-| `reasoning` | o3, o1, DeepSeek Reasoner | Logic and math |
+| `reasoning` | o3, DeepSeek Reasoner | Logic and math |
+| `free` | NVIDIA-hosted open models only | Development, zero-cost |
+| `coding` | Coding-tuned models | Code generation/review |
+| `glm` | Zhipu GLM-5 / GLM-5-Turbo | Flat-rate ($0.001/call) bulk |
+
+`mode` picks a model by intent in one hop. For prompt-aware selection (the scorer reads the prompt and picks the cheapest capable model), use `routing:"smart"` with a `routing_profile` instead — see [Smart Routing](../products/intelligence/smart-routing.md).
 
 ## Configuration
 

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -348,21 +348,6 @@ const result2 = await client.smartChat('Complex reasoning task...', {
 [TypeScript SDK Documentation](../../sdks/typescript.md#smart-routing-clawrouter)
 :::
 
-:::tab{label="XRPL (RLUSD)"}
-```python
-from blockrun_llm_xrpl import LLMClient
-
-client = LLMClient()  # Uses BLOCKRUN_XRPL_SEED
-
-# Smart routing works the same on XRPL
-result = client.smart_chat("Prove that sqrt(2) is irrational")
-print(result.model)  # "xai/grok-4-1-fast-reasoning"
-print(result.routing.tier)  # "REASONING"
-```
-
-[XRPL SDK Documentation](../../sdks/xrpl.md#smart-routing-clawrouter)
-:::
-
 ::::
 
 ### Routing Profiles

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -7,6 +7,8 @@ description: The Go SDK for BlockRun — call 50+ AI models, generate images, an
 
 The Go SDK for BlockRun provides access to 50+ AI models via x402 micropayments — pay per call in USDC, no API keys.
 
+**Source:** [github.com/BlockRunAI/blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go) · `go get github.com/BlockRunAI/blockrun-llm-go` · MIT
+
 :::tip{title="In a hurry?"}
 New to BlockRun? Run the [5-Minute Quickstart](../getting-started/quickstart.md) first to fund a wallet, then come back for the full SDK reference.
 :::

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -7,6 +7,8 @@ description: The official BlockRun Python SDK — call 50+ LLMs, smart routing, 
 
 The official Python SDK for BlockRun — pay per call in USDC, no API keys or subscriptions.
 
+**Source:** [github.com/BlockRunAI/blockrun-llm](https://github.com/BlockRunAI/blockrun-llm) · [PyPI: blockrun-llm](https://pypi.org/project/blockrun-llm/) · MIT
+
 :::tip{title="In a hurry?"}
 New to BlockRun? Run the [5-Minute Quickstart](../getting-started/quickstart.md) first to fund a wallet, then come back for the full SDK reference.
 :::

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -221,6 +221,218 @@ async def main():
 asyncio.run(main())
 ```
 
+## Specialized clients
+
+`LLMClient` covers chat and routing. Everything else — image, video, music, speech, voice, search, prices, RPC, and more — lives in a dedicated client class. Each is imported from `blockrun_llm` and constructed independently.
+
+:::note{title="Every client shares one constructor"}
+`Client(private_key=None, api_url=None, timeout=...)`. The key is resolved in order: the `private_key` argument → `BLOCKRUN_WALLET_KEY` → `BASE_CHAIN_WALLET_KEY` → `~/.blockrun/.session`. So if you've run `blockrun_wallet setup`, no argument is needed. Every client also exposes `get_wallet_address()` and `close()`.
+:::
+
+### Media generation
+
+#### `ImageClient`
+
+```python
+from blockrun_llm import ImageClient
+
+img = ImageClient()  # timeout defaults to 200s (gpt-image-2 at high res is slow)
+
+# Generate — default model google/nano-banana, default size 1024x1024
+res = img.generate("A cute cat astronaut, studio lighting", model="google/nano-banana-pro", size="1024x1024", n=1)
+print(res.data[0].url)
+
+# Edit / fusion — pass one data URI, or 2–4 to fuse (OpenAI ≤4, Nano Banana ≤3)
+res = img.edit("Place this logo on the t-shirt", image=["data:image/png;base64,...", "data:image/png;base64,..."])
+print(res.data[0].url)
+```
+
+Models: `google/nano-banana`, `google/nano-banana-pro`, `openai/gpt-image-1`, `openai/gpt-image-2`, `zai/cogview-4`, `xai/grok-imagine-image(-pro)`, `black-forest/flux-1.1-pro`.
+
+#### `VideoClient`
+
+```python
+from blockrun_llm import VideoClient
+
+vid = VideoClient()  # timeout 360s; submit→poll handled for you (budget 900s, re-signs mid-poll)
+
+res = vid.generate(
+    "a red apple spinning on a marble counter",
+    model="bytedance/seedance-2.0",
+    duration_seconds=5,
+    resolution="720p",          # 360p | 480p | 720p | 1080p | 4K (Seedance)
+    aspect_ratio="16:9",        # adaptive | 16:9 | 9:16 | 1:1 | 4:3 | 3:4 | 21:9 | 9:21
+    generate_audio=True,
+)
+print(res.data[0].url)
+```
+
+:::note{title="Image-to-video inputs are mutually exclusive"}
+Pass exactly one of `image_url` (first-frame), `real_face_asset_id` (a `ta_…` Virtual Portrait / RealFace asset), or `reference_image_urls` (≤9). `last_frame_url` seeds the final frame. `generate_from_content(content=[...])` accepts the Seedance `content[]` array.
+:::
+
+#### `MusicClient`
+
+```python
+from blockrun_llm import MusicClient
+
+music = MusicClient()
+res = music.generate("upbeat synthwave, driving bassline", model="minimax/music-2.5+", instrumental=True)
+print(res.data[0].url)   # URL expires ~24h; download promptly. ~$0.1575/track
+# For vocals: instrumental=False with lyrics="..." (passing both instrumental=True and lyrics raises ValueError)
+```
+
+#### `SpeechClient`
+
+```python
+from blockrun_llm import SpeechClient
+
+tts = SpeechClient()
+res = tts.generate("Hello from BlockRun!", model="elevenlabs/flash-v2.5", voice="sarah", response_format="mp3", speed=1.0)
+print(res.data[0].url)
+
+# Sound effects (flat $0.05/generation)
+sfx = tts.sound_effect("rain on a tin roof", duration_seconds=6.0)
+
+voices = tts.list_voices()  # free, 60 req/min/IP
+```
+
+Voices: `sarah`, `george`, `laura`, `charlie`, `river`, `roger`, `callum`, `harry`, or a raw ElevenLabs `voice_id`. Formats: `mp3` (default), `opus`, `pcm`, `wav`. Speed `0.7`–`1.2`. Billed per character (`chars/1000 × rate`, $0.001 floor) — flash/turbo cap 40k chars, multilingual-v2 10k, v3 5k.
+
+### Data & infrastructure
+
+#### `SearchClient` — Grok Live Search
+
+```python
+from blockrun_llm import SearchClient
+
+search = SearchClient()
+res = search.search("latest agent-payments news", sources=["web", "news"], max_results=10)  # x | web | news
+print(res.summary)
+for c in res.citations:
+    print(c)
+```
+
+`max_results` 1–50 (default 10); optional `from_date`/`to_date` (`YYYY-MM-DD`). Priced ~$0.025/source.
+
+#### `PriceClient` — crypto / FX / commodities / stocks
+
+```python
+from blockrun_llm import PriceClient
+
+px = PriceClient()                              # set require_wallet=False to use only free categories
+btc = px.price("crypto", "BTC-USD")             # crypto, fx, commodity are FREE; usstock, stocks are paid
+print(btc.price, btc.publishTime)
+
+bars = px.history("crypto", "BTC-USD", resolution="D", from_ts=1700000000, to_ts=1710000000)
+symbols = px.list_symbols("crypto", q="ETH", limit=20)
+```
+
+For `stocks`, pass `market` (`us`, `hk`, `jp`, `kr`, `gb`, `de`, `fr`, `nl`, `ie`, `lu`, `cn`, `ca`) and optionally `session` (`pre`/`post`/`on`). Resolutions: `1,5,15,60,240,D,W,M`.
+
+#### `SurfClient` — crypto data (80+ endpoints)
+
+```python
+from blockrun_llm import SurfClient
+
+surf = SurfClient()
+ranking = surf.call("market/ranking", params={"limit": 20})   # auto GET/POST from the catalog
+catalog = surf.endpoints()                                     # static: every path + tier + price
+```
+
+Tiers: T1 `$0.001` (reads/lists), T2 `$0.005` (AI rankings/trends/search), T3 `$0.020` (heavy LLM + on-chain SQL). Use `surf.get(path, params)` / `surf.post(path, body)` for explicit verbs.
+
+#### `RpcClient` — multi-chain JSON-RPC (40+ chains)
+
+```python
+from blockrun_llm import RpcClient
+
+rpc = RpcClient()
+res = rpc.call("ethereum", "eth_blockNumber")          # $0.002/call
+print(int(res.result, 16), "cache_hit:", res.cache_hit)
+
+# JSON-RPC 2.0 batch — billed $0.002 × N
+batch = rpc.batch("polygon", [{"method": "eth_blockNumber"}, {"method": "eth_gasPrice"}])
+```
+
+Networks accept names or aliases: `ethereum`/`eth`, `base`, `arbitrum`/`arb`, `optimism`/`op`, `polygon`/`matic`, `bsc`/`bnb`, `solana`/`sol`, `bitcoin`/`btc`, `ripple`/`xrp`, and ~30 more (EVM + non-EVM).
+
+### Identity & telephony
+
+#### `PhoneClient` — number provisioning + lookups
+
+```python
+from blockrun_llm import PhoneClient
+
+phone = PhoneClient()
+info  = phone.lookup("+14155552671")          # $0.01 — carrier + line type
+fraud = phone.lookup_fraud("+14155552671")    # $0.05 — + SIM-swap / call-forwarding signals
+num   = phone.buy_number(country="US", area_code="415")  # $5 / 30 days (settles after Twilio confirms)
+phone.renew_number(num["phone_number"])       # $5 / +30 days
+phone.list_numbers()                          # $0.001
+phone.release_number(num["phone_number"])     # free
+```
+
+#### `VoiceClient` — outbound AI phone calls
+
+```python
+from blockrun_llm import VoiceClient
+
+voice = VoiceClient()
+call = voice.call(
+    to="+14155552671",
+    task="Confirm the 3pm dental appointment and offer to reschedule if needed.",
+    voice="maya",            # nat | josh | maya | june | paige | derek | florian, or a Bland.ai id
+    max_duration=5,          # 1–30 minutes
+    language="en-US",
+)
+print(call["call_id"])
+status = voice.get_status(call["call_id"])   # free; transcript + recording_url once completed
+```
+
+`$0.54`/call. `from_` is auto-picked if your wallet owns exactly one provisioned number (see `PhoneClient.buy_number`).
+
+#### `PortraitClient` & `RealFaceClient` — `ta_…` identity assets for video
+
+```python
+from blockrun_llm import PortraitClient, RealFaceClient
+
+# Virtual Portrait — AI character, no KYC, $0.01 one-time
+portrait = PortraitClient()
+p = portrait.enroll("My Spokesperson", "https://example.com/character.jpg")
+print(p.asset_id)   # ta_xxxxxxxx → pass to VideoClient(real_face_asset_id=...)
+
+# RealFace — real person, requires on-phone liveness check, $0.01
+rf = RealFaceClient()
+init = rf.init("Jane Doe")            # render init.h5_link as a QR for the subject
+rf.wait_for_active(init.group_id)     # blocks until liveness passes (default 180s)
+asset = rf.enroll("Jane Doe", "https://example.com/jane.jpg", init.group_id)
+print(asset.asset_id)                 # ta_xxxxxxxx
+```
+
+### LLMClient extras: sandbox, DeFi, DEX, on-ramp, balances
+
+Beyond chat, `LLMClient` exposes:
+
+```python
+from blockrun_llm import LLMClient
+client = LLMClient()
+
+# Modal secure sandbox
+sb = client.modal_sandbox_create()
+out = client.modal_sandbox_exec(sb["id"], code="print(2+2)")
+client.modal_sandbox_status(sb["id"]); client.modal_sandbox_terminate(sb["id"])
+
+# DeFi (DeFiLlama) + DEX (0x)
+yields = client.defi_yields(); protocols = client.defi_protocols()
+quote  = client.dex_quote(...); gasless = client.dex_gasless_quote(...)
+
+# Wallet helpers
+print(client.get_balance())    # USDC on the active chain
+print(client.get_spending())   # session totals: {"total_usd": ..., "calls": ...}
+print(client.onramp())         # Coinbase on-ramp link
+```
+
 ## Prediction Markets (Powered by Predexon)
 
 Access real-time prediction market data from Polymarket, Kalshi, dFlow, Binance, and more via [Predexon](https://predexon.com). No API keys needed — pay-per-request via x402.

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -223,6 +223,85 @@ const result = await client.smartChat('Write a haiku about coding', {
 });
 ```
 
+## Drop-in OpenAI / Anthropic clients
+
+Already using the `openai` or `@anthropic-ai/sdk` packages? Swap the import and point it at BlockRun — your wallet key replaces the API key, everything else is the same shape.
+
+::::tabs
+
+:::tab{label="OpenAI-compatible"}
+```typescript
+import { OpenAI } from '@blockrun/llm';
+
+const client = new OpenAI({ walletKey: process.env.BLOCKRUN_WALLET_KEY });
+
+const res = await client.chat.completions.create({
+  model: 'openai/gpt-5.5',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+console.log(res.choices[0].message.content);
+
+// Streaming: set stream:true → returns an AsyncIterable of chunks
+const stream = await client.chat.completions.create({ model: 'openai/gpt-5.5', messages, stream: true });
+for await (const chunk of stream) process.stdout.write(chunk.choices[0]?.delta?.content ?? '');
+```
+:::
+
+:::tab{label="Anthropic-compatible"}
+```typescript
+import { Anthropic } from '@blockrun/llm';
+
+const client = new Anthropic({ walletKey: process.env.BLOCKRUN_WALLET_KEY });
+const msg = await client.messages.create({
+  model: 'anthropic/claude-opus-4.8',
+  max_tokens: 512,
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
+:::
+
+::::
+
+`create()` mirrors the upstream params (`model`, `messages`, `max_tokens`, `temperature`, `top_p`, `tools`, `tool_choice`, `response_format`, `stop`, `n`, penalties).
+
+## Specialized clients
+
+Like the Python SDK, every non-chat capability has its own client class, exported from `@blockrun/llm`. Each takes the same options (`{ walletKey | privateKey, apiUrl?, timeout? }`) and returns Promises.
+
+:::note{title="Shared instantiation"}
+Construct any client with `new XClient({ walletKey })` (or rely on `BLOCKRUN_WALLET_KEY` / `~/.blockrun/.session`). All expose `getWalletAddress()`.
+:::
+
+```typescript
+import {
+  ImageClient, VideoClient, MusicClient, SpeechClient, VoiceClient,
+  PhoneClient, PortraitClient, SearchClient, PriceClient, SurfClient, RpcClient,
+} from '@blockrun/llm';
+
+// Image — generate + edit/fuse
+const img = new ImageClient();
+const out = await img.generate('A sunset over mountains', { model: 'google/nano-banana', size: '1024x1024' });
+const fused = await img.edit('Place the logo on the shirt', [subjectDataUri, logoDataUri]);
+
+// Video — async submit→poll handled internally
+const vid = new VideoClient();
+const clip = await vid.generate('a red apple spinning', { model: 'bytedance/seedance-2.0', durationSeconds: 5, resolution: '720p' });
+
+// Speech + sound effects
+const tts = new SpeechClient();
+const audio = await tts.generate('Hello!', { voice: 'sarah', responseFormat: 'mp3' });
+
+// Search, prices, crypto data, RPC
+const search = new SearchClient();
+const news   = await search.search('agent payments', { sources: ['web', 'news'], maxResults: 10 });
+const px     = new PriceClient();
+const btc    = await px.price('crypto', 'BTC-USD');
+const rpc    = new RpcClient();
+const block  = await rpc.call('ethereum', 'eth_blockNumber');   // $0.002/call
+```
+
+The full method surface mirrors the Python SDK (see the [Python](python.md) page for per-method params, pricing tiers, and `ta_…` identity assets); the only differences are camelCase options and `Promise` returns.
+
 ## Prediction Markets (Powered by Predexon)
 
 Access real-time prediction market data from Polymarket, Kalshi, dFlow, Binance, and more via [Predexon](https://predexon.com). No API keys needed — pay-per-request via x402.

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -7,6 +7,8 @@ description: The official BlockRun TypeScript/JavaScript SDK — call 50+ LLMs, 
 
 The official TypeScript/JavaScript SDK for BlockRun — pay per call in USDC, no API keys or subscriptions.
 
+**Source:** [github.com/BlockRunAI/blockrun-llm-ts](https://github.com/BlockRunAI/blockrun-llm-ts) · [npm: @blockrun/llm](https://www.npmjs.com/package/@blockrun/llm) · MIT
+
 :::tip{title="In a hurry?"}
 New to BlockRun? Run the [5-Minute Quickstart](../getting-started/quickstart.md) first to fund a wallet, then come back for the full SDK reference.
 :::

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -1,15 +1,17 @@
 ---
-title: XRPL SDK (Python)
-description: The official BlockRun Python SDK for the XRP Ledger — call 50+ LLMs over x402 micropayments paid in RLUSD, with no API keys.
+title: XRPL SDK (Python) — deprecated
+description: The BlockRun XRPL SDK (pay-on-XRPL with RLUSD) is deprecated. Use Base or Solana for new integrations.
 ---
 
 # XRPL SDK (Python)
 
-The official Python SDK for BlockRun on the XRP Ledger, using RLUSD for micropayments — pay per call, no API keys.
+:::danger{title="Deprecated — being sunset"}
+The XRPL pay-on-XRPL SDK (`blockrun-llm-xrpl`, RLUSD settlement on the XRP Ledger) is being **sunset** and is no longer recommended for new integrations. Use the [Python SDK](python.md) or [TypeScript SDK](typescript.md) on **Base** or **Solana** instead — same models, same API, actively maintained.
 
-:::tip{title="In a hurry?"}
-New to BlockRun? See the [5-Minute Quickstart](../getting-started/quickstart.md) for the Base/Solana flow, then use this page for the XRPL-specific RLUSD setup.
+This page remains for reference for existing XRPL integrations. Read-only XRP/XRPL access via [Multi-chain RPC](../api-reference/multi-chain-rpc.md) is unaffected and stays supported.
 :::
+
+The Python SDK for BlockRun on the XRP Ledger, using RLUSD for micropayments — pay per call, no API keys.
 
 ::::steps
 

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -22,7 +22,7 @@ The same paths are available on each gateway. The 402 response advertises which 
 | `blockrun.ai` | Base mainnet — `eip155:8453` | USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | Per-call onchain | Default gateway. EIP-3009 / x402 v2. |
 | `sol.blockrun.ai` | Solana mainnet — `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | USDC SPL `EPjFWdd5AufqSSqeM2qN1xzybapC8C4wEBmGbV4Vu5JLs` | Per-call onchain | Solana SPL transfers. |
 | `nano.blockrun.ai` | Base mainnet via Circle Gateway | USDC | Batched (Nanopayments) | Gas-free, sub-cent floor, batched onchain settlement. See [the Nanopayments launch post](https://blockrun.ai/signal/nanopayments-mainnet-circle-gateway). |
-| `xrpl.blockrun.ai` | XRP Ledger | RLUSD (Ripple-issued USD) | Per-call onchain | Facilitator: t54.ai. Native XRPL payment channels. SDK: [`blockrun-llm-xrpl`](../sdks/xrpl.md). |
+| `xrpl.blockrun.ai` | XRP Ledger | RLUSD (Ripple-issued USD) | Per-call onchain | **Deprecated (being sunset)** — use Base or Solana for new integrations. See the [XRPL SDK notice](../sdks/xrpl.md). |
 | `testnet.blockrun.ai` | Base Sepolia — `eip155:84532` | USDC `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | Per-call onchain | Free test USDC. Smaller model catalog. |
 
 All gateways implement [x402 v2](https://x402.org). Facilitators: Coinbase CDP for Base, native Solana verification, t54.ai for XRPL.

--- a/docs/x402/payment-flow.md
+++ b/docs/x402/payment-flow.md
@@ -85,10 +85,37 @@ const signature = await wallet.signTypedData({
 });
 ```
 
+The domain and types are the standard EIP-3009 definition for USDC. On **Base** (chain `eip155:8453`):
+
+```typescript
+const USDC_DOMAIN = {
+  name: 'USD Coin',
+  version: '2',
+  chainId: 8453,
+  verifyingContract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC on Base
+};
+
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from',        type: 'address' },
+    { name: 'to',          type: 'address' },
+    { name: 'value',       type: 'uint256' }, // amount in micro-USDC (6 decimals)
+    { name: 'validAfter',  type: 'uint256' }, // unix seconds
+    { name: 'validBefore', type: 'uint256' }, // unix seconds
+    { name: 'nonce',       type: 'bytes32' }, // random 32 bytes, single-use
+  ],
+};
+```
+
 Key points:
 - Private key never leaves the client
 - Authorization expires in 5 minutes (`validBefore`)
 - Clock skew tolerance of 10 minutes (`validAfter`)
+- `value` is micro-USDC: `$0.001` → `"1000"`
+- The header value is the **base64 of the JSON payment payload** shown in the next step (`btoa(JSON.stringify(payload))`)
+
+:::note{title="Paying on Solana"}
+On the Solana gateway (`sol.blockrun.ai`, network `solana:…`) the 402 advertises USDC-SPL (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, 6 decimals) and the authorization is signed for the SPL transfer instead of EIP-3009. The SDKs pick the right scheme automatically from the `accepts[]` entry.
 :::
 
 :::step{title="Retry with Payment"}


### PR DESCRIPTION
Fills the depth gaps for **agent + API developers** on top of the Greptile format rollout. All grounded in SDK/MCP/x402 source; verified rendering locally (0 raw `:::` leaks on every changed page).

## What
- **sdks/python.md, sdks/typescript.md** — new *Specialized clients* section documenting every exported client class (Image, Video, Music, Speech, Voice, Phone, Portrait, RealFace, Search, Price, Surf, Rpc) with signatures, params, pricing tiers, and runnable examples. TS also gets the **OpenAI/Anthropic drop-in** clients (swap baseURL + walletKey). These classes were exported but undocumented — devs had to read source.
- **mcp/blockrun-mcp.md** — parameter tables for `blockrun_chat` (mode enum + `routing`/`routing_profile`), `blockrun_wallet` (action enum: status/setup/chain/budget/delegate/revoke/report), `blockrun_search`; completed the smart-routing mode table (`free`/`coding`/`glm`).
- **x402/payment-flow.md** — defined the USDC EIP-712 `USDC_DOMAIN` + `TransferWithAuthorization` types inline (previously referenced but never shown), base64 header note, Solana SPL variant.

## Not changed
Smart-routing already has a thorough explainer in `products/routing/clawrouter.md` (14-dimension scorer, tiers, fallback chains) — linked it from the MCP doc instead of duplicating.

## Verification
Local prod build + render: `sdks/python`, `sdks/typescript`, `mcp/blockrun-mcp`, `x402/payment-flow` all render components with **0 raw directive leaks**; internal link targets confirmed to exist.