### PR TITLE
docs: reposition around what we sell (Franklin/MCP/ClawRouter/SDK); Examples & recipes; demote frameworks to Community

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,12 +37,16 @@ Pick the path that matches how you work.
 
 ::::cards
 
+:::card{title="I want an autonomous agent" href="products/franklin.md" icon="Rocket"}
+Franklin — the AI agent with a wallet. Writes code and spends USDC across 55+ models and paid APIs. Free to start.
+:::
+
 :::card{title="I use Claude Code / Cursor" href="getting-started/quickstart.md" icon="Terminal"}
 One MCP install adds 18 `blockrun_*` tools to your assistant. Best for Claude Code, Cursor, and other MCP clients.
 :::
 
 :::card{title="I'm building an agent / backend" href="getting-started/sdk-developers.md" icon="Code"}
-Drop-in SDKs for Python, TypeScript, and Go — plus framework plugins for ElizaOS, AgentKit, and LangChain.
+Drop-in SDKs for Python, TypeScript, and Go — pay-per-call, OpenAI-compatible.
 :::
 
 :::card{title="Set up my wallet" href="getting-started/wallet-setup.md" icon="Wallet"}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,10 @@
 * [Agent Developers](getting-started/agent-developers.md)
 * [Wallet Setup](getting-started/wallet-setup.md)
 
+## Franklin
+
+* [Franklin Agent](products/franklin.md)
+
 ## Intelligence
 
 * [Overview](products/intelligence/overview.md)
@@ -36,13 +40,6 @@
 * [BlockRun MCP](mcp/blockrun-mcp.md)
 * [Skills](mcp/skills.md)
 * [Troubleshooting](mcp/troubleshooting.md)
-
-## Frameworks
-
-* [ElizaOS](frameworks/elizaos.md)
-* [AgentKit](frameworks/agentkit.md)
-* [GOAT SDK](frameworks/goat.md)
-* [LangChain](frameworks/langchain.md)
 
 ## SDKs
 
@@ -83,5 +80,13 @@
 ## Resources
 
 * [FAQ](resources/faq.md)
+* [Examples & recipes](resources/examples.md)
 * [Ecosystem](resources/ecosystem.md)
 * [Changelog](resources/changelog.md)
+
+## Community integrations
+
+* [ElizaOS](frameworks/elizaos.md)
+* [AgentKit](frameworks/agentkit.md)
+* [GOAT SDK](frameworks/goat.md)
+* [LangChain](frameworks/langchain.md)

--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -1,0 +1,73 @@
+---
+title: Franklin Agent
+description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 55+ models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
+---
+
+# Franklin Agent
+
+**The AI agent with a wallet.** Other coding agents write code; Franklin writes code *and spends money to get the job done* — picking the best model per task, buying data, generating media, paying for search, all autonomously from one USDC wallet.
+
+**Source:** [github.com/BlockRunAI/Franklin](https://github.com/BlockRunAI/Franklin) · [npm: @blockrun/franklin](https://www.npmjs.com/package/@blockrun/franklin) · Apache-2.0
+
+:::tip{title="YOPO — You Only Pay Outcome"}
+Not a subscription (pay for access), not generic pay-per-call (pay for trying). You set an outcome and a budget; Franklin decides what to call, what to pay for, and when to stop. Provider cost + 5%, settled per action in USDC — no monthly fees, no rate limits.
+:::
+
+## Quick start
+
+::::steps
+
+:::step{title="Install"}
+Requires Node.js 20.19+ (Node 22 LTS recommended).
+
+```bash
+npm install -g @blockrun/franklin
+```
+:::
+
+:::step{title="Run — free out of the box"}
+Franklin starts on free NVIDIA models (Nemotron, Qwen3 Coder), no wallet needed.
+
+```bash
+franklin
+```
+:::
+
+:::step{title="Fund a wallet to unlock everything"}
+Add USDC to unlock Claude, GPT, Gemini, Grok, and every paid API (trading data, image/video, web search).
+
+```bash
+franklin setup base      # or: franklin setup solana
+franklin balance         # show address + USDC balance
+```
+:::
+
+::::
+
+No install? Run it directly with `npx @blockrun/franklin`.
+
+## How Franklin fits
+
+Franklin is the autonomous agent on top of the BlockRun stack — it uses the same pieces you can use directly:
+
+- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 55+ providers.
+- **Paid APIs** — search, market data, media, RPC, and more, paid per call over [x402](../x402/how-it-works.md).
+- **One wallet** — the wallet is the identity; fund it on Base or Solana ([Wallet Setup](../getting-started/wallet-setup.md)).
+
+## What's next?
+
+::::cards
+
+:::card{title="ClawRouter" href="routing/clawrouter.md" icon="Route"}
+The router Franklin uses — 14-dimension scoring picks the cheapest capable model.
+:::
+
+:::card{title="BlockRun MCP" href="../mcp/blockrun-mcp.md" icon="Terminal"}
+Prefer Claude Code / Cursor? Get the same tools as MCP commands.
+:::
+
+:::card{title="Wallet Setup" href="../getting-started/wallet-setup.md" icon="Wallet"}
+Fund on Base or Solana and set budgets for autonomous spend.
+:::
+
+::::

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -1,0 +1,76 @@
+---
+title: Examples & recipes
+description: Open-source examples, Claude Code skills, sample agents, and curated lists showing how to build on BlockRun — pay-per-use over x402, no API keys.
+---
+
+# Examples & recipes
+
+Working code and patterns from the BlockRun ecosystem. Everything here pays per use in USDC over x402 — clone, fund a wallet, run.
+
+## Claude Code skills
+
+Drop-in skills that turn a BlockRun capability into a one-line Claude Code command.
+
+::::cards
+
+:::card{title="nano-banana-blockrun" href="https://github.com/BlockRunAI/nano-banana-blockrun" icon="Image"}
+Image generation as a Claude Code skill, paid via x402 micropayments.
+:::
+
+:::card{title="GPT-Image-2 / SeeDance" href="https://github.com/BlockRunAI/Claude-Code-GPT-IMAGE2-SeeDance-BlockRun" icon="Image"}
+Run any GPT-Image-2 or Seedance prompt as a one-liner — `/headshot`, `/dance`, `/poster` + a 1010-case library.
+:::
+
+:::card{title="lobster.cash skill" href="https://github.com/BlockRunAI/lobstercash-blockrun-skill" icon="Zap"}
+BlockRun skill for the lobster.cash OpenClaw plugin — 40+ models paid with Solana USDC.
+:::
+
+::::
+
+## Sample agents & apps
+
+::::cards
+
+:::card{title="franklin-canvas" href="https://github.com/BlockRunAI/franklin-canvas" icon="Boxes"}
+Node-based AI media studio — generate image/video/music on an infinite canvas, or let an agent build a short film from one prompt.
+:::
+
+:::card{title="polymarket-agent" href="https://github.com/BlockRunAI/polymarket-agent" icon="TrendingUp"}
+Autonomous prediction-market trading agent using x402 micropayments.
+:::
+
+:::card{title="circle-nanopayment-sample" href="https://github.com/BlockRunAI/circle-nanopayment-sample" icon="Wallet"}
+Gas-free USDC micropayments for API access via Circle Gateway.
+:::
+
+:::card{title="alpha-mcp" href="https://github.com/BlockRunAI/alpha-mcp" icon="TrendingUp"}
+AI crypto-trading MCP server — technical analysis, sentiment, execution.
+:::
+
+::::
+
+## Curated lists
+
+::::cards
+
+:::card{title="awesome-mcp-servers" href="https://github.com/BlockRunAI/awesome-mcp-servers" icon="Book"}
+A collection of MCP servers.
+:::
+
+:::card{title="awesome-finance-mcp" href="https://github.com/BlockRunAI/awesome-finance-mcp" icon="Book"}
+MCP servers for AI finance agents.
+:::
+
+:::card{title="awesome-healthcare-mcp" href="https://github.com/BlockRunAI/awesome-healthcare-mcp" icon="Book"}
+MCP servers for healthcare and medical.
+:::
+
+:::card{title="awesome-OpenClaw-Money-Maker" href="https://github.com/BlockRunAI/awesome-OpenClaw-Money-Maker" icon="Book"}
+Ways to make money with OpenClaw — automations, skills, services.
+:::
+
+::::
+
+:::note
+More examples land in the [BlockRunAI org](https://github.com/BlockRunAI) regularly. Building something? It can be listed here — see [Ecosystem](ecosystem.md).
+:::


### PR DESCRIPTION
Repositions the docs around the products we actually sell, per direction.

## Changes
- **New: Franklin product page** (`products/franklin.md`) — flagship 'AI agent with a wallet' (YOPO, `@blockrun/franklin`, free-to-start → fund wallet), shown as a top-level sidebar section and the first Introduction entry card. Grounded in the Franklin repo README.
- **New: Examples & recipes** (`resources/examples.md`) — aggregates the ecosystem's skill/sample/curated repos (nano-banana, GPT-Image-2/SeeDance, franklin-canvas, polymarket-agent, circle-nanopayment-sample, alpha-mcp, awesome-* lists), grouped by category.
- **Third-party frameworks demoted** — `Frameworks` section renamed **Community integrations** and moved to the bottom of the sidebar (ElizaOS/AgentKit/GOAT/LangChain pages kept, just no longer a primary focus).
- **Introduction** — added a Franklin card; dropped the framework-plugin emphasis from the SDK card.

Primary products (Franklin, MCP, ClawRouter, SDK) all have prominent sections; frameworks are now clearly secondary.

## Verification
`pnpm build` clean; local render: Franklin + Examples pages render with 0 raw `:::` leaks; sidebar shows Franklin (top), Examples (Resources), Community integrations (bottom).