### PR TITLE
docs(align): Go module case fix + agent-developers reframed to Franklin/SDK/MCP-first + framework community notes

### DIFF
--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -7,6 +7,10 @@ description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-ch
 
 Use BlockRun with Coinbase AgentKit for wallet-enabled AI agents — AgentKit holds assets and executes trades, BlockRun pays for the intelligence.
 
+:::note{title="Community integration"}
+BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
+:::
+
 [AgentKit](https://github.com/coinbase/agentkit) is Coinbase's framework for building AI agents with wallet capabilities. Combined with BlockRun, your agents can both hold assets AND pay for AI intelligence.
 
 ## Overview

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -7,6 +7,10 @@ description: Add the BlockRun plugin to ElizaOS so your agents reach 50+ AI mode
 
 Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 50+ models paid per request over x402.
 
+:::note{title="Community integration"}
+BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
+:::
+
 [ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 50+ AI models via x402 micropayments.
 
 ## Setup

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -7,8 +7,8 @@ description: Combine GOAT SDK's cross-chain execution with BlockRun's 50+ AI mod
 
 Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 50+ models with x402 micropayments.
 
-:::note{title="Pre-Integration"}
-Official `@goat-sdk/plugin-blockrun` is not yet published. Use BlockRun alongside GOAT via the TypeScript SDK as shown below.
+:::note{title="Community integration — pre-release"}
+No official `@goat-sdk/plugin-blockrun` yet; use BlockRun alongside GOAT via the [TypeScript SDK](../sdks/typescript.md) as shown below. BlockRun's primary paths are [Franklin](../products/franklin.md), the [MCP](../mcp/blockrun-mcp.md), and the SDKs.
 :::
 
 ## Quick Start

--- a/docs/frameworks/langchain.md
+++ b/docs/frameworks/langchain.md
@@ -9,8 +9,8 @@ Use BlockRun as an LLM provider in LangChain — a custom LLM class handles x402
 
 [LangChain](https://github.com/langchain-ai/langchain) is the most popular framework for building LLM applications. BlockRun provides a custom LLM class that handles x402 payments automatically.
 
-:::note{title="Planned"}
-Official LangChain integration is in development. For now, use the BlockRun SDK directly alongside LangChain, or use the custom provider below.
+:::note{title="Community integration — planned"}
+No official LangChain package yet; use the custom provider below or the BlockRun [SDK](../sdks/python.md) directly. BlockRun's primary paths are [Franklin](../products/franklin.md), the [MCP](../mcp/blockrun-mcp.md), and the SDKs.
 :::
 
 ## Setup

--- a/docs/getting-started/agent-developers.md
+++ b/docs/getting-started/agent-developers.md
@@ -1,13 +1,17 @@
 ---
 title: Agent Developers
-description: Build AI agents that pay for their own intelligence — 50+ models via x402 micropayments, with framework plugins for ElizaOS, AgentKit, and LangChain.
+description: Build AI agents that pay for their own intelligence — 50+ models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
 ---
 
 # Agent Developers
 
 Build AI agents that pay for their own intelligence.
 
-This guide is for developers using agent frameworks like ElizaOS, AgentKit, GOAT SDK, or LangChain. BlockRun provides the intelligence layer — 50+ AI models via x402 micropayments.
+This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 50+ models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
+
+:::tip{title="Fastest path: Franklin"}
+Want an agent that already spends autonomously? [Franklin](../products/franklin.md) is one install (`npm install -g @blockrun/franklin`) and runs free out of the box — fund a wallet to unlock everything.
+:::
 
 ## Why BlockRun for Agents?
 

--- a/docs/getting-started/sdk-developers.md
+++ b/docs/getting-started/sdk-developers.md
@@ -47,7 +47,7 @@ console.log(response);
 
 :::tab{label="Go"}
 ```bash
-go get github.com/blockrunai/blockrun-llm-go
+go get github.com/BlockRunAI/blockrun-llm-go
 ```
 
 ```go
@@ -55,7 +55,7 @@ package main
 
 import (
     "fmt"
-    blockrun "github.com/blockrunai/blockrun-llm-go"
+    blockrun "github.com/BlockRunAI/blockrun-llm-go"
 )
 
 func main() {

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -17,7 +17,7 @@ New to BlockRun? Run the [5-Minute Quickstart](../getting-started/quickstart.md)
 
 :::step{title="Install"}
 ```bash
-go get github.com/blockrunai/blockrun-llm-go
+go get github.com/BlockRunAI/blockrun-llm-go
 ```
 :::
 
@@ -28,7 +28,7 @@ package main
 import (
     "fmt"
     "os"
-    blockrun "github.com/blockrunai/blockrun-llm-go"
+    blockrun "github.com/BlockRunAI/blockrun-llm-go"
 )
 
 func main() {
@@ -214,7 +214,7 @@ package main
 import (
     "fmt"
     "time"
-    blockrun "github.com/blockrunai/blockrun-llm-go"
+    blockrun "github.com/BlockRunAI/blockrun-llm-go"
 )
 
 type TradingBot struct {
@@ -248,7 +248,7 @@ func main() {
 
 ## Links
 
-- [GitHub: blockrun-llm-go](https://github.com/blockrunai/blockrun-llm-go)
+- [GitHub: blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go)
 - [Models Reference](../api-reference/models.md)
 - [SDK Developer Guide](../getting-started/sdk-developers.md)
 


### PR DESCRIPTION
End-to-end alignment pass (from a 3-audit consistency review). Link health was 100% (0 broken / 329), XRPL sunset clean, package names correct — these are the remaining fixes:

- **Go module case** (correctness bug): `github.com/blockrunai/blockrun-llm-go` → `github.com/BlockRunAI/blockrun-llm-go` in sdks/go.md + getting-started/sdk-developers.md (6 occurrences incl. imports; Go module paths are case-sensitive so the lowercase form fails).
- **Positioning**: agent-developers.md now leads with Franklin / SDK / MCP as the primary paths (frameworks reframed as 'already using one?' alternatives) + a 'Fastest path: Franklin' callout.
- **Framework pages** (elizaos/agentkit/langchain/goat): added a 'Community integration' note pointing to Franklin/MCP/SDK as the primary entry points.

Verified: pnpm build clean; all changed pages render with 0 raw ::: leaks.

Out of scope (flagged to owner, not guessed): model-count inconsistency (50+/55+/60+), stale model IDs in prose (claude-opus-4.6/kimi-k2.6/gemini naming), and two orphan files (products/creation/music-generation.md dup, api-reference/x-twitter.md).