### PR TITLE
docs: canonical model count → 60+ everywhere

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ description: BlockRun is economic infrastructure for the agent era — AI agents
 
 **Agents that pay, spend, and trade.**
 
-BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 50+ LLMs, media generation, real-time data, and on-chain execution.
+BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 60+ LLMs, media generation, real-time data, and on-chain execution.
 
 :::tip{title="In a hurry?"}
 Jump to the [5-Minute Quickstart](getting-started/quickstart.md) and make your first paid call.
@@ -38,7 +38,7 @@ Pick the path that matches how you work.
 ::::cards
 
 :::card{title="I want an autonomous agent" href="products/franklin.md" icon="Rocket"}
-Franklin — the AI agent with a wallet. Writes code and spends USDC across 55+ models and paid APIs. Free to start.
+Franklin — the AI agent with a wallet. Writes code and spends USDC across 60+ models and paid APIs. Free to start.
 :::
 
 :::card{title="I use Claude Code / Cursor" href="getting-started/quickstart.md" icon="Terminal"}
@@ -62,7 +62,7 @@ Four product families, one payment layer.
 ::::cards
 
 :::card{title="Intelligence" href="products/intelligence/overview.md" icon="Brain"}
-50+ LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
+60+ LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
 :::
 
 :::card{title="Routing" href="products/routing/clawrouter.md" icon="Route"}

--- a/docs/api-reference/chat-completions.md
+++ b/docs/api-reference/chat-completions.md
@@ -1,6 +1,6 @@
 ---
 title: Chat Completions
-description: OpenAI-compatible Chat Completions endpoint for 50+ LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
+description: OpenAI-compatible Chat Completions endpoint for 60+ LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
 ---
 
 # Chat Completions
@@ -176,7 +176,7 @@ console.log(result.choices[0].message.content);
 ::::cards
 
 :::card{title="Browse all models" href="models.md" icon="Brain"}
-50+ LLMs with live pricing — pick the right model and ID for your call.
+60+ LLMs with live pricing — pick the right model and ID for your call.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -357,7 +357,7 @@ Real-time web, news, and X/Twitter search via Grok Live Search.
 :::
 
 :::card{title="Chat Completions" href="chat-completions.md" icon="Brain"}
-Feed grounded search results into any of 50+ LLMs for synthesis.
+Feed grounded search results into any of 60+ LLMs for synthesis.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -1,6 +1,6 @@
 ---
 title: Models
-description: List and price 50+ LLMs plus image, video, and music models from one unified BlockRun API, with a flat 5% platform fee over provider rates.
+description: List and price 60+ LLMs plus image, video, and music models from one unified BlockRun API, with a flat 5% platform fee over provider rates.
 ---
 
 # Models
@@ -56,7 +56,7 @@ Each model object in the response includes:
 ## Available Models (50+ across chat / image / video / voice)
 
 :::note
-50+ models total across all categories: 41 visible LLMs + 8 image + 4 video + 1 music, plus ~36 deprecated / superseded LLM IDs that remain routable for backwards compatibility but are hidden from the catalog.
+60+ models across all categories — LLMs plus image, video, music, and voice. Additional deprecated / superseded LLM IDs remain routable for backwards compatibility but are hidden from the catalog. Call `GET /api/v1/models` for the exact live list.
 :::
 
 All prices shown are provider rates. BlockRun adds a **5% platform fee** to cover infrastructure costs.

--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -1,6 +1,6 @@
 ---
 title: AgentKit Integration
-description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 50+ AI models.
+description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 60+ AI models.
 ---
 
 # AgentKit Integration

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -1,17 +1,17 @@
 ---
 title: ElizaOS Integration
-description: Add the BlockRun plugin to ElizaOS so your agents reach 50+ AI models via x402 micropayments — no per-provider API keys.
+description: Add the BlockRun plugin to ElizaOS so your agents reach 60+ AI models via x402 micropayments — no per-provider API keys.
 ---
 
 # ElizaOS Integration
 
-Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 50+ models paid per request over x402.
+Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 60+ models paid per request over x402.
 
 :::note{title="Community integration"}
 BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
 :::
 
-[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 50+ AI models via x402 micropayments.
+[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 60+ AI models via x402 micropayments.
 
 ## Setup
 

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -1,11 +1,11 @@
 ---
 title: GOAT SDK Integration
-description: Combine GOAT SDK's cross-chain execution with BlockRun's 50+ AI models, paid per request over x402 — until the official plugin ships.
+description: Combine GOAT SDK's cross-chain execution with BlockRun's 60+ AI models, paid per request over x402 — until the official plugin ships.
 ---
 
 # GOAT SDK Integration
 
-Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 50+ models with x402 micropayments.
+Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 60+ models with x402 micropayments.
 
 :::note{title="Community integration — pre-release"}
 No official `@goat-sdk/plugin-blockrun` yet; use BlockRun alongside GOAT via the [TypeScript SDK](../sdks/typescript.md) as shown below. BlockRun's primary paths are [Franklin](../products/franklin.md), the [MCP](../mcp/blockrun-mcp.md), and the SDKs.

--- a/docs/frameworks/langchain.md
+++ b/docs/frameworks/langchain.md
@@ -1,6 +1,6 @@
 ---
 title: LangChain Integration
-description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 50+ models.
+description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 60+ models.
 ---
 
 # LangChain Integration

--- a/docs/getting-started/agent-developers.md
+++ b/docs/getting-started/agent-developers.md
@@ -1,13 +1,13 @@
 ---
 title: Agent Developers
-description: Build AI agents that pay for their own intelligence — 50+ models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
+description: Build AI agents that pay for their own intelligence — 60+ models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
 ---
 
 # Agent Developers
 
 Build AI agents that pay for their own intelligence.
 
-This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 50+ models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
+This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 60+ models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
 
 :::tip{title="Fastest path: Franklin"}
 Want an agent that already spends autonomously? [Franklin](../products/franklin.md) is one install (`npm install -g @blockrun/franklin`) and runs free out of the box — fund a wallet to unlock everything.

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Code Users
-description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 50+ models, images, and live data.
+description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 60+ models, images, and live data.
 ---
 
 # Claude Code Users
@@ -85,7 +85,7 @@ Use GPT-5 to get a second opinion on this code
 Ask Grok what's trending on X right now
 ```
 
-Claude automatically routes to 50+ AI models and pays via x402.
+Claude automatically routes to 60+ AI models and pays via x402.
 
 ### Trading (alpha-mcp)
 
@@ -182,7 +182,7 @@ Create images via micropayments with the nano-banana skill.
 :::
 
 :::card{title="Explore all models" href="../products/intelligence/overview.md" icon="Brain"}
-50+ LLMs with live pricing, plus smart routing to cut costs automatically.
+60+ LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 ::::

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -98,7 +98,7 @@ The full list of 18 `blockrun_*` tools — chat, image, video, search, markets, 
 :::
 
 :::card{title="Explore the models" href="../products/intelligence/overview.md" icon="Brain"}
-50+ LLMs with live pricing, plus smart routing to cut costs automatically.
+60+ LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -1,11 +1,11 @@
 ---
 title: BlockRun MCP
-description: A Model Context Protocol server that gives Claude Code 50+ models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
+description: A Model Context Protocol server that gives Claude Code 60+ models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
 ---
 
 # BlockRun MCP
 
-Give Claude Code access to 50+ AI models, 80+ crypto data endpoints, voice calls, image/video/music generation, prediction markets, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 60+ AI models, 80+ crypto data endpoints, voice calls, image/video/music generation, prediction markets, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 

--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -1,6 +1,6 @@
 ---
 title: Franklin Agent
-description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 55+ models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
+description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 60+ models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
 ---
 
 # Franklin Agent
@@ -50,7 +50,7 @@ No install? Run it directly with `npx @blockrun/franklin`.
 
 Franklin is the autonomous agent on top of the BlockRun stack — it uses the same pieces you can use directly:
 
-- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 55+ providers.
+- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 60+ providers.
 - **Paid APIs** — search, market data, media, RPC, and more, paid per call over [x402](../x402/how-it-works.md).
 - **One wallet** — the wallet is the identity; fund it on Base or Solana ([Wallet Setup](../getting-started/wallet-setup.md)).
 

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -1,11 +1,11 @@
 ---
 title: Intelligence
-description: BlockRun Intelligence gives your agent 50+ LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
+description: BlockRun Intelligence gives your agent 60+ LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
 ---
 
 # Intelligence
 
-AI accesses any LLM. 50+ models, pay-per-request.
+AI accesses any LLM. 60+ models, pay-per-request.
 
 BlockRun's Intelligence product gives your AI agent access to models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, and more — without managing API keys or subscriptions.
 

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -7,7 +7,7 @@ description: ClawRouter is a smart LLM router for OpenClaw that picks the optima
 
 **Save 78% on LLM costs. Automatically.**
 
-ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 50+ models, zero API keys.
+ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 60+ models, zero API keys.
 
 :::tip{title="In a hurry?"}
 Install, fund a wallet, then run `/model blockrun/auto` in any OpenClaw conversation — that's it.
@@ -456,7 +456,7 @@ No. AI model access requires internet. But routing decisions are made locally.
 ::::cards
 
 :::card{title="View all models" href="../intelligence/overview.md" icon="Brain"}
-50+ LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, and the free NVIDIA tier.
+60+ LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, and the free NVIDIA tier.
 :::
 
 :::card{title="Check pricing" href="../intelligence/pricing.md" icon="Zap"}

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -12,7 +12,7 @@ Projects, integrations, and partners building with BlockRun and x402.
 | Product | Description | Link |
 |---------|-------------|------|
 | [alpha-mcp](https://github.com/BlockRunAI/alpha-mcp) | AI crypto trading for Claude | [GitHub](https://github.com/BlockRunAI/alpha-mcp) |
-| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP server (v0.4.2) for 50+ AI models, images, video, music, voice, prediction markets, crypto data, sandbox runtime, smart routing | [GitHub](https://github.com/BlockRunAI/blockrun-mcp) |
+| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP server (v0.4.2) for 60+ AI models, images, video, music, voice, prediction markets, crypto data, sandbox runtime, smart routing | [GitHub](https://github.com/BlockRunAI/blockrun-mcp) |
 | [nano-banana](https://github.com/BlockRunAI/nano-banana-blockrun) | Image generation skill | [GitHub](https://github.com/BlockRunAI/nano-banana-blockrun) |
 
 ## API Products

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -14,7 +14,7 @@ Frequently asked questions about BlockRun — payments, products, models, wallet
 BlockRun is economic infrastructure for AI agents. It provides:
 - **Trading** — AI that analyzes markets and executes trades (alpha-mcp)
 - **Creation** — AI that creates optimized content and images
-- **Intelligence** — Access to 50+ AI models via x402 micropayments
+- **Intelligence** — Access to 60+ AI models via x402 micropayments
 
 ### What makes BlockRun different?
 
@@ -101,7 +101,7 @@ No. alpha-mcp is free. You only pay for intelligence (sentiment analysis) and ne
 
 ### Which AI models are available?
 
-50+ models including:
+60+ models including:
 - OpenAI (GPT-5.5, GPT-5.4, GPT-5.2, o1)
 - Anthropic (Claude Opus 4, Sonnet 4, Haiku 4.5)
 - Google (Gemini 3 Pro, Gemini 2.5 Flash)

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -1,11 +1,11 @@
 ---
 title: Go SDK
-description: The Go SDK for BlockRun — call 50+ AI models, generate images, and manage wallets over x402 micropayments with no API keys.
+description: The Go SDK for BlockRun — call 60+ AI models, generate images, and manage wallets over x402 micropayments with no API keys.
 ---
 
 # Go SDK
 
-The Go SDK for BlockRun provides access to 50+ AI models via x402 micropayments — pay per call in USDC, no API keys.
+The Go SDK for BlockRun provides access to 60+ AI models via x402 micropayments — pay per call in USDC, no API keys.
 
 **Source:** [github.com/BlockRunAI/blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go) · `go get github.com/BlockRunAI/blockrun-llm-go` · MIT
 
@@ -261,7 +261,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 50+ models with live pricing to pick the right one for each call.
+Browse all 60+ models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python SDK
-description: The official BlockRun Python SDK — call 50+ LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun Python SDK — call 60+ LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # Python SDK
@@ -860,7 +860,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 50+ models with live pricing to pick the right one for each call.
+Browse all 60+ models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: TypeScript SDK
-description: The official BlockRun TypeScript/JavaScript SDK — call 50+ LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun TypeScript/JavaScript SDK — call 60+ LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # TypeScript SDK
@@ -731,7 +731,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 50+ models with live pricing to pick the right one for each call.
+Browse all 60+ models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -412,7 +412,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 50+ models with live pricing to pick the right one for each call.
+Browse all 60+ models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}


### PR DESCRIPTION
Standardizes the model count to the canonical **60+** across all docs (was a mix of 50+/55+). Generalized the models.md catalog note to avoid asserting a stale per-category sum; points to GET /api/v1/models for the live list.