### PR TITLE
Add Counterra — open-source accounting for x402 spend

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -54,7 +54,7 @@ BlockRun works with the x402 facilitator network:
 |---------|----------|-------------|
 | [LLM_trader](https://github.com/qrak/LLM_trader) | Trading Bot | Autonomous crypto trading bot with Visual Cortex for chart analysis |
 | [Voyage GEO](https://github.com/onvoyage-ai/voyage-geo-agent) | AI Analytics | Generative Engine Optimization - track AI brand mentions across multiple models |
-
+| [Counterra](https://github.com/billiondollarapps/counterra) | Accounting | Open-source accounting for x402 spend — decodes settlements into journal entries with per-agent attribution, exports to QuickBooks/Xero |
 ### Claude Code Tools
 
 | Tool | Description | Install |


### PR DESCRIPTION
Counterra is open-source (Apache-2.0) accounting for x402 payments: it decodes settlements on Base and Solana into journal entries with per-agent attribution and exports to QuickBooks/Xero.

Relevant to BlockRun users specifically — the MCP README notes on-chain receipts aren't tax invoices. Counterra turns that spend into books. Also maintaining an open seller registry (counterra.xyz/providers.json) where BlockRun endpoints are evidence-verified.