### PR TITLE
docs: add PulseNetwork to Community Integrations

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -54,6 +54,7 @@ BlockRun works with the x402 facilitator network:
 |---------|----------|-------------|
 | [LLM_trader](https://github.com/qrak/LLM_trader) | Trading Bot | Autonomous crypto trading bot with Visual Cortex for chart analysis |
 | [Voyage GEO](https://github.com/onvoyage-ai/voyage-geo-agent) | AI Analytics | Generative Engine Optimization - track AI brand mentions across multiple models |
+| [PulseNetwork](https://pulsenetwork.theaslangroupllc.com) | API Catalog | 76-origin x402 API catalog (950+ pay-per-call intelligence endpoints: token safety, macro, geopolitical, sports, clinical trials) — purchasable by BlockRun-powered agents via CDP/PayAI facilitator discovery |
 
 ### Claude Code Tools
 


### PR DESCRIPTION
Follows up on #17 (data provider application). Adds PulseNetwork to the Community Integrations table: 76-origin x402 API catalog, 950+ pay-per-call intelligence endpoints (token safety across 8 chains incl. Solana memecoins, macro/economic primitives, geopolitical risk, clinical trials, sports, prediction markets), settling USDC on Base + Solana through the same CDP/PayAI facilitator network BlockRun already routes through — so BlockRun-powered agents can discover and buy from the catalog today with no extra integration.

Discovery endpoints: [/.well-known/x402.json manifests on all origins](https://pulsenetwork.theaslangroupllc.com/.well-known/x402.json), [llms.txt](https://pulsenetwork.theaslangroupllc.com/llms.txt), [OpenAPI](https://pulsenetwork.theaslangroupllc.com/openapi.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)