### PR TITLE
fix(docs): drop markers from docs/ — this site renders them into view

### DIFF
--- a/brand/README.md
+++ b/brand/README.md
@@ -33,3 +33,20 @@ node scripts/sync-brand-numbers.mjs           # rewrite markers from the snapsho
 node scripts/sync-brand-numbers.mjs --check   # exit 1 on drift, never fetches (CI)
 node scripts/sync-brand-numbers.mjs --refresh # pull a newer artifact, then rewrite
 ```
+
+### `docs/` must NOT carry markers
+
+An HTML comment is invisible only where something renders it as HTML. GitHub
+does. **blockrun.ai does not** — `docs/` is symlinked into the blockrun repo and
+served through its docs renderer, which escapes the comment and prints it:
+
+```
+JSON-RPC 2.0 access to <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> blockchains
+```
+
+The same file therefore reads fine on GitHub and broken on the site. `docs/`
+keeps plain numbers; blockrun asserts them in `brand-numbers.docs.test.ts` and
+fails if a marker ever reappears there.
+
+Markers are fine in `README.md` and `ECOSYSTEM.md` — those are only ever
+rendered by GitHub.

--- a/docs/api-reference/chat-completions.md
+++ b/docs/api-reference/chat-completions.md
@@ -222,7 +222,7 @@ console.log(result.choices[0].message.content);
 ::::cards
 
 :::card{title="Browse all models" href="models.md" icon="Brain"}
-<!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> chat models with live pricing — pick the right model and ID for your call.
+66 chat models with live pricing — pick the right model and ID for your call.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/multi-chain-rpc.md
+++ b/docs/api-reference/multi-chain-rpc.md
@@ -5,13 +5,13 @@ description: Standard JSON-RPC 2.0 access to every supported blockchain through 
 
 # Multi-chain RPC — one endpoint, every chain
 
-Standard JSON-RPC 2.0 access to <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> blockchains through a single endpoint. No account, no API key, no monthly plan — pay **$0.004 per call** in USDC over x402. Built for AI agents that read on-chain data across many chains from one wallet.
+Standard JSON-RPC 2.0 access to 40 blockchains through a single endpoint. No account, no API key, no monthly plan — pay **$0.004 per call** in USDC over x402. Built for AI agents that read on-chain data across many chains from one wallet.
 
 BlockRun proxies upstream RPC gateways with x402 settlement, so an agent can query any supported chain without onboarding to a node provider.
 
 ## The problem it solves
 
-Traditional RPC providers (Alchemy, Infura, QuickNode) make you sign up, manage an API key, and pick a monthly plan with rate-limit tiers — **per chain**. An agent that needs Ethereum *and* Base *and* Solana *and* Polygon ends up with four accounts and four keys. BlockRun gives you one endpoint for <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains, paid per call, with on-chain settlement receipts.
+Traditional RPC providers (Alchemy, Infura, QuickNode) make you sign up, manage an API key, and pick a monthly plan with rate-limit tiers — **per chain**. An agent that needs Ethereum *and* Base *and* Solana *and* Polygon ends up with four accounts and four keys. BlockRun gives you one endpoint for 40 chains, paid per call, with on-chain settlement receipts.
 
 ## Endpoint
 

--- a/docs/api-reference/prediction-markets.md
+++ b/docs/api-reference/prediction-markets.md
@@ -395,7 +395,7 @@ Feed market and wallet data into an LLM to analyze odds and positioning.
 :::
 
 :::card{title="Multi-chain RPC" href="multi-chain-rpc.md" icon="Route"}
-Read on-chain data across <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains to complement wallet identity lookups.
+Read on-chain data across 40 chains to complement wallet identity lookups.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ A terminal, and ~$5 of USDC on **Base** (or Solana). Don't have USDC yet? Any Co
 ::::tabs
 
 :::tab{label="Claude Code (MCP)"}
-Best for Claude Code, Cursor, and other MCP clients — natural-language access to all <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools.
+Best for Claude Code, Cursor, and other MCP clients — natural-language access to all 19 tools.
 
 ```bash
 claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -96,7 +96,7 @@ Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana")
 
 ## Available Tools
 
-The MCP exposes <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools to Claude:
+The MCP exposes 19 tools to Claude:
 
 ### `blockrun_chat`
 

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -179,7 +179,7 @@ Generate images via micropayments with the bundled skill.
 :::
 
 :::card{title="BlockRun MCP" href="blockrun-mcp.md" icon="Boxes"}
-The MCP server and the <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools skills build on.
+The MCP server and the 19 tools skills build on.
 :::
 
 :::card{title="Troubleshooting" href="troubleshooting.md" icon="Search"}

--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -50,7 +50,7 @@ No install? Run it directly with `npx @blockrun/franklin`.
 
 Franklin is the autonomous agent on top of the BlockRun stack — it uses the same pieces you can use directly:
 
-- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> chat models.
+- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 66 chat models.
 - **Paid APIs** — search, market data, media, RPC, and more, paid per call over [x402](../x402/how-it-works.md).
 - **One wallet** — the wallet is the identity; fund it on Base or Solana ([Wallet Setup](../getting-started/wallet-setup.md)).
 

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -101,7 +101,7 @@ The 5% covers:
 **No subscriptions. No minimums. No prepaid credits.**
 
 :::tip{title="Cut costs automatically"}
-Don't want to pick models by hand? [ClawRouter](../routing/clawrouter.md) routes each request to the cheapest model that can handle it — <!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->% lower cost than pinning one flagship for every request.
+Don't want to pick models by hand? [ClawRouter](../routing/clawrouter.md) routes each request to the cheapest model that can handle it — 87% lower cost than pinning one flagship for every request.
 :::
 
 ## Quick Start

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -5,7 +5,7 @@ description: ClawRouter is a smart LLM router for OpenClaw that picks the optima
 
 # ClawRouter
 
-**<!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->% cheaper than pinning one flagship for every request — <!-- br:savings.ecoVsBaselinePct -->98<!-- /br:savings.ecoVsBaselinePct -->% on `eco`. Automatically.**
+**87% cheaper than pinning one flagship for every request — 98% on `eco`. Automatically.**
 
 ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 64 models, zero API keys.
 

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -33,7 +33,7 @@ Projects, integrations, and partners building with BlockRun and x402.
 | **Search** | `/v1/search` | $0.025/source | ✅ Live |
 | **Exa Web Search** | `/api/v1/exa/*` | $0.002–0.012 | ✅ Live |
 | **0x Swap (DEX)** | `/api/v1/zerox/*` | Free | ✅ Live |
-| **Multi-chain RPC** | `/api/v1/rpc/{network}` (<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains) | $0.004/call | ✅ Live |
+| **Multi-chain RPC** | `/api/v1/rpc/{network}` (40 chains) | $0.004/call | ✅ Live |
 | **Prediction Markets** | `/v1/pm/*` | $0.0095 | ✅ Live |
 | **Trading Markets** | `/api/v1/markets/*` | $0.003 | ✅ Live |
 | **Modal Sandbox** | `/v1/modal/*` | $0.003–0.012 | ✅ Live |

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -14,7 +14,7 @@ Frequently asked questions about BlockRun — payments, products, models, wallet
 BlockRun is economic infrastructure for AI agents. It provides:
 - **Trading** — AI that analyzes markets and executes trades (alpha-mcp)
 - **Creation** — generate images, video, music, and speech, paid per output
-- **Intelligence** — Access to <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> chat/LLM models via x402 micropayments
+- **Intelligence** — Access to 66 chat/LLM models via x402 micropayments
 
 ### What makes BlockRun different?
 

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -136,7 +136,7 @@ Real-time and historical prices. All `list` endpoints are free. **Crypto, FX, an
 
 ## Blockchain RPC (Tatum)
 
-Standard JSON-RPC 2.0 to <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains through one endpoint — no API key. EVM (`eth_*`) and non-EVM methods. See [Multi-chain RPC](../api-reference/multi-chain-rpc.md).
+Standard JSON-RPC 2.0 to 40 chains through one endpoint — no API key. EVM (`eth_*`) and non-EVM methods. See [Multi-chain RPC](../api-reference/multi-chain-rpc.md).
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|


### PR DESCRIPTION
#19 put brand markers throughout `docs/`. That was wrong, and it is **live on blockrun.ai right now**:

> JSON-RPC 2.0 access to `<!-- br:chains.rpc -->`40`<!-- /br:chains.rpc -->` blockchains through a single endpoint.

## Why it shipped

An HTML comment is invisible only where something renders it as HTML.

- **GitHub** renders it → the comment disappears → the diff in #19 looked correct
- **blockrun.ai** does not. `docs/` is symlinked into the blockrun repo and served through its docs renderer, which *escapes* the comment:

```html
access to <!-- -->&lt;!-- br:chains.rpc --&gt;<!-- -->40<!-- -->&lt;!-- /br:chains.rpc --&gt;
```

The same file reads fine in review and broken on the site. That gap is why nobody caught it.

## The fix

`docs/` goes back to plain numbers — 14 markers stripped across 12 files.

blockrun asserts those numbers in a new `brand-numbers.docs.test.ts` and fails if a marker ever reappears in the tree. **The constraint belongs to the renderer, so the guard lives with the renderer** rather than in this repo, which would have to remember a rule about someone else's rendering.

`README.md` and `ECOSYSTEM.md` keep their markers — those are only ever rendered by GitHub, where the mechanism works as intended. `brand/README.md` now documents the split.

## Companion

The same class of bug hit `public/llms.txt` and friends, which are served as `text/plain` — fixed in the blockrun PR alongside this.