### PR TITLE
docs(pricing): the published Gemini rates were quoting a bug we just fixed

### DIFF
--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -129,10 +129,10 @@ These flagship models reject all sampling parameters (`temperature`, `top_p`, `t
 | Model ID | Name | Input Price | Output Price | Context |
 |----------|------|-------------|--------------|---------|
 | `google/gemini-3.1-pro` | Gemini 3.1 Pro | $2.00/M | $12.00/M | 1M |
-| `google/gemini-3.5-flash` | Gemini 3.5 Flash | $0.50/M | $3.00/M | 1M |
+| `google/gemini-3.5-flash` | Gemini 3.5 Flash | $1.50/M | $9.00/M | 1M |
 | `google/gemini-2.5-pro` | Gemini 2.5 Pro | $1.25/M | $10.00/M | 1M |
 | `google/gemini-2.5-flash` | Gemini 2.5 Flash | $0.30/M | $2.50/M | 1M |
-| `google/gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite | $0.10/M | $0.40/M | 1M |
+| `google/gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite | $0.25/M | $1.50/M | 1M |
 | `google/gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite | $0.10/M | $0.40/M | 1M |
 
 Gemini **Pro** models (`gemini-2.5-pro`, `gemini-3.1-pro`) bill a **long-context tier** — 2x input, 1.5x output above 200K prompt tokens (mirrors Google's official pricing: `gemini-2.5-pro` is $2.50/M in · $15.00/M out, `gemini-3.1-pro` is $4.00/M in · $18.00/M out above the threshold). Flash / Flash-Lite are flat-priced.

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -47,7 +47,7 @@ Reference provider rates per 1M tokens (BlockRun adds a 5% margin at billing —
 | Model | Input | Output |
 |-------|-------|--------|
 | Gemini 3.1 Pro | $2.00/M | $12.00/M |
-| Gemini 3.5 Flash | $0.50/M | $3.00/M |
+| Gemini 3.5 Flash | $1.50/M | $9.00/M |
 
 ### Z.AI
 | Model | Input | Output |

--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -25,7 +25,7 @@ The 5% margin covers:
 |-------|------------------|
 | GPT-5.5 | ~200K input tokens |
 | DeepSeek V4 Flash Chat | ~5M input tokens |
-| Gemini 3.5 Flash | ~2M input tokens |
+| Gemini 3.5 Flash | ~635K input tokens |
 | Image generation | ~10–65 images |
 | **Free tier** (8 models — reasoning, coding, and vision) | **Unlimited (FREE)** |
 
@@ -62,7 +62,7 @@ The free tier costs $0 — 10 reasoning, coding, and vision models with no per-t
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
 | Gemini 3.1 Pro | $2.10 | $12.60 |
-| Gemini 3.5 Flash | $0.53 | $3.15 |
+| Gemini 3.5 Flash | $1.58 | $9.45 |
 
 Gemini Pro models double the input rate and add 50% to the output rate above 200K prompt tokens (the whole request reprices), mirroring Google's official long-context pricing — e.g. Gemini 2.5 Pro is $2.63 in · $15.75 out above the threshold. Flash tiers are flat.
 

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -149,7 +149,7 @@ Default `auto` profile primaries (cost-balanced; switch to `free` profile for $0
 | Tier | Model (auto) | Cost | Free-tier fallback | Use Case |
 |------|-------|------|--------------------|----------|
 | **SIMPLE** | moonshot/kimi-k2.7 | $0.95/M in / $4.00/M out | free-tier model (FREE) | Q&A, summaries, simple tasks |
-| **MEDIUM** | google/gemini-3.5-flash | $0.50/M in / $3.00/M out | free-tier model (FREE) | Analysis, writing, coding |
+| **MEDIUM** | google/gemini-3.5-flash | $1.50/M in / $9.00/M out | free-tier model (FREE) | Analysis, writing, coding |
 | **COMPLEX** | google/gemini-3.1-pro | $2.00/M in / $12.00/M out | free-tier model (FREE) | Advanced reasoning, research |
 | **REASONING** | deepseek/deepseek-reasoner | $0.28/M in / $0.42/M out | free-tier model (FREE) | Math, logic, proofs |
 
@@ -160,7 +160,7 @@ Default `auto` profile primaries (cost-balanced; switch to `free` profile for $0
 | Prompt | Routed To | Cost | Savings |
 |--------|-----------|------|---------|
 | "What is 2+2?" | DeepSeek | $0.40/M | 99% |
-| "Summarize this article" | Gemini 3.5 Flash | $3.00/M | 90% |
+| "Summarize this article" | Gemini 3.5 Flash | $9.00/M | 70% |
 | "Build a React component" | Claude Sonnet 4.6 | $15.00/M | 80% |
 | "Prove this theorem" | DeepSeek Reasoner | $0.42/M | 99% |
 | "Run 50 parallel searches" | Kimi K2.7 | $4.00/M | 87% |

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -119,7 +119,7 @@ BlockRun routes to these providers via x402:
 |----------|--------|---------------------------|
 | OpenAI | GPT-5.5, GPT-5.4, GPT-5.4 Pro, GPT-5.2 | $1.75–$30.00 / $14.00–$180.00 |
 | Anthropic | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $0.80–$10.00 / $4.00–$50.00 |
-| Google | Gemini 3.1 Pro, Gemini 3.5 Flash | $0.50–$2.00 / $3.00–$12.00 |
+| Google | Gemini 3.1 Pro, Gemini 3.5 Flash | $1.50–$2.00 / $9.00–$12.00 |
 | DeepSeek | DeepSeek V4 Flash Chat, DeepSeek V4 Pro, DeepSeek Reasoner | $0.20–$0.44 / $0.40–$0.87 |
 | xAI | Grok 4.5, Grok 4.3, Grok 4 Fast, Grok Code Fast 1 | $0.20–$3.00 / $0.50–$18.00 |
 | Z.AI | GLM-5.2 (1M context), GLM-5.1, GLM-5, GLM-5 Turbo | $0.60–$1.40 / $1.92–$4.40 |


### PR DESCRIPTION
Companion to [blockrun#304](https://github.com/BlockRunAI/blockrun/pull/304), which corrects `google/gemini-3.5-flash` from `0.50/3.00` to Google's `1.50/9.00`.

`/v1/models` and `/api/pricing` read `models.ts` live, so the moment #304 lands the API quotes $1.50 while every page in this repo still says $0.50. Advertising a third of what we charge is a worse failure than the underbilling it replaces: the underbilling was invisible to the caller, a stale public quote is not.

## Changed

| File | Was | Now |
|---|---|---|
| `docs/api-reference/models.md` | `$0.50/M \| $3.00/M` | `$1.50/M \| $9.00/M` |
| `docs/products/intelligence/overview.md` | `$0.50/M \| $3.00/M` | `$1.50/M \| $9.00/M` |
| `docs/products/intelligence/pricing.md` (post-markup) | `$0.53 \| $3.15` | `$1.58 \| $9.45` |
| `docs/products/intelligence/pricing.md` ($1 buys) | `~2M input tokens` | `~635K input tokens` |
| `docs/products/routing/clawrouter.md` (MEDIUM tier) | `$0.50/M in / $3.00/M out` | `$1.50/M in / $9.00/M out` |
| `docs/products/routing/clawrouter.md` (example) | `$3.00/M \| 90%` | `$9.00/M \| 70%` |
| `docs/resources/ecosystem.md` | `$0.50–$2.00 / $3.00–$12.00` | `$1.50–$2.00 / $9.00–$12.00` |

Raw COGS everywhere except `products/intelligence/pricing.md`, which quotes post-markup (verified: its Gemini 3.1 Pro row is `$2.10/$12.60` = `2.00/12.00 × 1.05`).

## Second bug, same shape

`docs/api-reference/models.md` listed `gemini-3.1-flash-lite` at `$0.10/M | $0.40/M`. That is `gemini-2.5-flash-lite`'s rate verbatim; the real one is `0.25/1.50`. Found while checking which convention the column used. Fixed here, now `$0.25/M | $1.50/M`.

## On the 70%

The clawrouter savings column has no consistent baseline across its rows (`$15.00 → 80%` implies 75, `$0.40 → 99%` implies 40, `$3.00 → 90%` implies 30). 70% is arithmetic against the baseline that row implied for itself, not a re-derived marketing claim. Worth a proper pass separately.

## Not changed, needs a product call

`docs/products/intelligence/pricing.md:216` still recommends Gemini 3.5 Flash for "Quick responses — Fast + cheap". At $1.50/$9.00 it is no longer the cheap option; `gemini-3-flash-preview` at `0.50/3.00` and Claude Haiku 4.5 at `0.80/4.00` both undercut it. Changing which model the docs recommend is a product decision, not a price sync, so it is left alone here.

## Verified

`blockrun` full suite against this tree: 1086 tests, 99 files, all pass, including `brand-numbers.docs.test.ts` which walks this repo's `docs/`. `tsc --noEmit` clean.