### PR TITLE
chore: MCP ships 20 tools

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -59,7 +59,7 @@ BlockRun works with the x402 facilitator network:
 
 | Tool | Description | Install |
 |------|-------------|---------|
-| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP Server — <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools across <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> AI models, image/video/music/speech gen, voice calls, crypto data (Surf), prediction markets, DEX prices, raw JSON-RPC (<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains), DeFi TVL/yields, sandboxed code exec, search | `claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest` |
+| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP Server — <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools across <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> AI models, image/video/music/speech gen, voice calls, crypto data (Surf), prediction markets, DEX prices, raw JSON-RPC (<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains), DeFi TVL/yields, sandboxed code exec, search | `claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest` |
 | [nano-banana-blockrun](https://github.com/BlockRunAI/nano-banana-blockrun) | Image generation skill via x402 micropayments | Claude Code skill |
 
 ### Framework Integrations

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 
 **Who it's for:** Developers who don't want to manage 7 different provider accounts and API keys. Pay per request with USDC, one wallet covers everything.
 
-**<!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools included:**
+**<!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools included:**
 
 | Tool | What it does |
 |------|-------------|

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -21,7 +21,7 @@
     "aliases": 202
   },
   "mcp": {
-    "tools": 19
+    "tools": 20
   },
   "chains": {
     "rpc": 40

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ A terminal, and ~$5 of USDC on **Base** (or Solana). Don't have USDC yet? Any Co
 ::::tabs
 
 :::tab{label="Claude Code (MCP)"}
-Best for Claude Code, Cursor, and other MCP clients — natural-language access to all 19 tools.
+Best for Claude Code, Cursor, and other MCP clients — natural-language access to all 20 tools.
 
 ```bash
 claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -96,7 +96,7 @@ Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana")
 
 ## Available Tools
 
-The MCP exposes 19 tools to Claude:
+The MCP exposes 20 tools to Claude:
 
 ### `blockrun_chat`
 

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -179,7 +179,7 @@ Generate images via micropayments with the bundled skill.
 :::
 
 :::card{title="BlockRun MCP" href="blockrun-mcp.md" icon="Boxes"}
-The MCP server and the 19 tools skills build on.
+The MCP server and the 20 tools skills build on.
 :::
 
 :::card{title="Troubleshooting" href="troubleshooting.md" icon="Search"}


### PR DESCRIPTION
`@blockrun/mcp` [0.33.0](https://github.com/BlockRunAI/blockrun-mcp/releases/tag/v0.33.0) is published to npm and the MCP registry, adding a 20th tool: `blockrun_polymarket_read` — a read-only companion to `blockrun_polymarket` (positions, open orders, and live CLOB order previews that cannot sign or submit).

- `brand-numbers.json` snapshot 19 → 20, markers regenerated in `README.md` and `ECOSYSTEM.md`
- three prose counts in `docs/` are not marker-bound, updated by hand

`sync-brand-numbers.mjs --check` passes.