### PR TITLE
feat(brand): derive Go module homepages too, and close the last description gap

### DIFF
--- a/brand/plan-repo-metadata.mjs
+++ b/brand/plan-repo-metadata.mjs
@@ -103,6 +103,16 @@ function derivedHomepage(repo, shape) {
       return `https://www.npmjs.com/package/${name}`;
     } catch { return null; }
   }
+  if (shape === "go") {
+    // A Go module's import path IS its published page. Verified against
+    // pkg.go.dev before proposing, same as npm and PyPI.
+    const mod = fileFrom(repo.name, "go.mod")?.match(/^module\s+(\S+)/m)?.[1];
+    if (!mod) return null;
+    try {
+      gh(["api", "--silent", `https://pkg.go.dev/${mod}`]);
+      return `https://pkg.go.dev/${mod}`;
+    } catch { return null; }
+  }
   if (shape === "py-pypi") {
     const toml = fileFrom(repo.name, "pyproject.toml");
     const name = toml?.match(/^\s*name\s*=\s*["']([^"']+)["']/m)?.[1];


### PR DESCRIPTION
## Go modules

A Go module's **import path is its published page**. `go.mod` states it, pkg.go.dev either serves it or does not — same shape as the npm and PyPI derivations, verified before proposing.

```
blockrun-llm-go     -> https://pkg.go.dev/github.com/BlockRunAI/blockrun-llm-go      (HTTP 200)
blockrun-llm-go-vip -> https://pkg.go.dev/github.com/BlockRunAI/blockrun-llm-go-vip  (HTTP 200)
```

## The last missing description

`blockrun-llm-vip` was the one public repo with **no description at all**. I had been treating that as needing author intent I could not supply.

But the author did supply it — **in the README**, which says the thing plainly: native passthrough that subclasses the official Anthropic/OpenAI SDKs and swaps only transport and base URL, so responses come back verbatim. The description is a compression of what is already written, not invention.

## Coverage

| | before this round | now |
|---|---|---|
| public repos with a description | 35/36 | **36/36** |
| public repos with a homepage | 4/36 | **18/36** |

## The remaining 18 are honestly empty

They publish no artifact — awesome lists, `.github`, `branding`, `renovate-config`, samples, the decommissioned xrpl client. There is nothing to derive, and pointing them all at blockrun.ai would be **filling a field rather than answering it**.