### PR TITLE
docs(ecosystem): add Status column to the x402 facilitator table

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -28,14 +28,16 @@ BlockRun is a unified API gateway — pay per request with USDC, no API keys nee
 
 BlockRun works with the x402 facilitator network:
 
-| Facilitator | Network | Discovery Endpoint |
-|-------------|---------|-------------------|
-| [Coinbase CDP](https://coinbase.com/cloud) | Base, Ethereum | `api.cdp.coinbase.com/platform/v2/x402/discovery/resources` |
-| [PayAI](https://payai.network) | Base, Solana | `facilitator.payai.network/discovery/resources` |
-| [QuestFlow](https://questflow.ai) | Base | `facilitator.questflow.ai/discovery/resources` |
-| [AnySpend](https://anyspend.com) | Base | `mainnet.anyspend.com/x402/discovery/resources` |
-| [AurraCloud](https://aurracloud.com) | Base | `x402-facilitator.aurracloud.com/discovery/resources` |
-| [thirdweb](https://thirdweb.com) | Base, Ethereum | `api.thirdweb.com/v1/payments/x402/discovery/resources` |
+| Facilitator | Network | Discovery Endpoint | Status |
+|-------------|---------|-------------------|--------|
+| [Coinbase CDP](https://coinbase.com/cloud) | Base, Ethereum | `api.cdp.coinbase.com/platform/v2/x402/discovery/resources` | ✅ Live |
+| [PayAI](https://payai.network) | Base, Solana | `facilitator.payai.network/discovery/resources` | ✅ Live |
+| [QuestFlow](https://questflow.ai) | Base | `facilitator.questflow.ai/discovery/resources` | ⚠️ 500 |
+| [AnySpend](https://anyspend.com) | Base | `mainnet.anyspend.com/x402/discovery/resources` | ✅ Live |
+| [AurraCloud](https://aurracloud.com) | Base | `x402-facilitator.aurracloud.com/discovery/resources` | ❌ Unreachable |
+| [thirdweb](https://thirdweb.com) | Base, Ethereum | `api.thirdweb.com/v1/payments/x402/discovery/resources` | ✅ Live |
+
+<sub>Status column verified 2026-08-02 by GET on each discovery endpoint. `facilitator.questflow.ai` returned HTTP 500 (`not authorized on x402-prod to execute command aggregate: "discoverable_resources"`); `x402-facilitator.aurracloud.com` did not resolve (its apex `aurracloud.com` does). The other four returned resource lists.</sub>
 
 ## Partners
 


### PR DESCRIPTION
Two of the six discovery endpoints in the facilitator table are currently down, so the list reads as all-working when it is not. This adds a **Status** column (using the same `✅ Live` convention as the *API Products* table above) plus a short dated note.

Verified 2026-08-02 with a `GET` on each discovery endpoint:

| Facilitator | Discovery endpoint | Result |
|---|---|---|
| Coinbase CDP | `…/x402/discovery/resources` | ✅ resources returned |
| PayAI | `facilitator.payai.network/discovery/resources` | ✅ resources returned |
| QuestFlow | `facilitator.questflow.ai/discovery/resources` | ⚠️ HTTP 500 — `not authorized on x402-prod to execute command aggregate: "discoverable_resources"` |
| AnySpend | `mainnet.anyspend.com/x402/discovery/resources` | ✅ resources returned |
| AurraCloud | `x402-facilitator.aurracloud.com/discovery/resources` | ❌ does not resolve (its apex `aurracloud.com` does) |
| thirdweb | `…/payments/x402/discovery/resources` | ✅ resources returned |

Only the two failing rows are flagged; the note is dated so it's clearly a point-in-time check. Happy to drop the inline note and keep just the column, or vice-versa, whichever you prefer.