### PR TITLE
docs: drop 6 sunset endpoints, correct ~140 stale prices, add DefiLlama + Market Data

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -66,6 +66,8 @@
 * [Polymarket Funding](api-reference/polymarket-funding.md)
 * [Modal Sandbox](api-reference/modal-sandbox.md)
 * [Surf — Crypto Data](api-reference/surf.md)
+* [DefiLlama](api-reference/defillama.md)
+* [Market Data (Pyth)](api-reference/market-data.md)
 * [Multi-chain RPC](api-reference/multi-chain-rpc.md)
 * [Phone & Voice](api-reference/voice-phone.md)
 * [Models](api-reference/models.md)

--- a/docs/api-reference/defillama.md
+++ b/docs/api-reference/defillama.md
@@ -1,0 +1,142 @@
+---
+title: DefiLlama
+description: DeFi protocol TVL, per-chain TVL, yield pools and token prices from DefiLlama's dataset, paid per call in USDC over x402 — no account, no API key.
+---
+
+# DefiLlama
+
+DeFi's reference dataset — every protocol DefiLlama tracks, TVL by chain, every
+yield pool, and token prices across chains. Pay per call in USDC over x402; no
+account and no API key.
+
+DefiLlama publishes under Apache 2.0 with explicit free-for-commercial-use
+terms. BlockRun wraps it with metering, timeouts and a single payment rail so an
+agent can budget a call the same way it budgets any other endpoint.
+
+## Endpoints
+
+| Endpoint | Method | Price | Description |
+|----------|--------|-------|-------------|
+| `/api/v1/defillama/protocols` | GET | $0.006 | Every DeFi protocol tracked, with current and historical TVL across chains |
+| `/api/v1/defillama/protocol/{slug}` | GET | $0.006 | Detailed TVL + breakdown for one protocol |
+| `/api/v1/defillama/chains` | GET | $0.006 | TVL for every chain DefiLlama tracks |
+| `/api/v1/defillama/yields` | GET | $0.006 | Every tracked yield pool (lending, LPs, staking, vaults) with current APY/TVL |
+| `/api/v1/defillama/prices/{coins}` | GET | $0.002 | Token price lookup, comma-separated coin identifiers |
+
+Prices are quoted in every 402 response. Read them at request time rather than
+copying from this page.
+
+---
+
+## GET /api/v1/defillama/protocols
+
+Every protocol DefiLlama indexes, with current TVL and per-chain breakdown.
+
+```bash
+curl https://blockrun.ai/api/v1/defillama/protocols \
+  -H "X-Payment: <x402_payment_token>"
+```
+
+Returns a JSON array. Each entry carries `name`, `slug`, `category`, `chains`,
+`tvl` and change-over-time fields. It is a large payload — expect several MB.
+
+---
+
+## GET /api/v1/defillama/protocol/{slug}
+
+One protocol in detail, addressed by its DefiLlama slug.
+
+```bash
+curl https://blockrun.ai/api/v1/defillama/protocol/aave \
+  -H "X-Payment: <x402_payment_token>"
+```
+
+| Parameter | In | Required | Description |
+|-----------|----|----------|-------------|
+| `slug` | path | Yes | DefiLlama protocol slug — `aave`, `uniswap`, `lido`, … |
+
+Slugs come from the `slug` field of `/protocols`. An unknown slug returns `404`
+and is **not** charged.
+
+The heaviest protocols (`uniswap`, for one) return multi-MB payloads; the
+upstream timeout is 25s.
+
+---
+
+## GET /api/v1/defillama/chains
+
+Current TVL totals for every chain.
+
+```bash
+curl https://blockrun.ai/api/v1/defillama/chains \
+  -H "X-Payment: <x402_payment_token>"
+```
+
+---
+
+## GET /api/v1/defillama/yields
+
+Every yield pool DefiLlama tracks, with APY and TVL — lending markets, LP
+positions, staking and vaults.
+
+```bash
+curl https://blockrun.ai/api/v1/defillama/yields \
+  -H "X-Payment: <x402_payment_token>"
+```
+
+Filter client-side on `chain`, `project`, `symbol`, `apy` and `tvlUsd`.
+
+---
+
+## GET /api/v1/defillama/prices/{coins}
+
+Token prices in DefiLlama's coin syntax. Cheaper than the other four at $0.002
+because it is a point lookup rather than a full dataset.
+
+```bash
+curl "https://blockrun.ai/api/v1/defillama/prices/coingecko:bitcoin,ethereum:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" \
+  -H "X-Payment: <x402_payment_token>"
+```
+
+| Parameter | In | Required | Description |
+|-----------|----|----------|-------------|
+| `coins` | path | Yes | Comma-separated coin identifiers |
+
+Identifier forms:
+
+- `coingecko:<id>` — e.g. `coingecko:bitcoin`
+- `<chain>:<address>` — e.g. `ethereum:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`, `solana:So11111111111111111111111111111111111111112`
+
+The response is an object keyed by the identifier you passed, each with
+`price`, `symbol`, `decimals` and `timestamp`.
+
+---
+
+## Errors
+
+| Status | Meaning | Charged? |
+|--------|---------|----------|
+| `402` | Payment required — the response carries the exact amount and `payTo` | No |
+| `404` | Unknown protocol slug or coin identifier | No |
+| `502` | DefiLlama upstream error or timeout | No |
+
+Payment settles only after a successful upstream response, so a failed call
+never costs you anything.
+
+## What's next?
+
+::::cards
+
+:::card{title="Surf — Crypto Data" href="surf.md" icon="ChartLine"}
+Exchange, on-chain and social data across 83 endpoints.
+:::
+
+:::card{title="0x Swap (DEX)" href="zerox-swap.md" icon="ArrowLeftRight"}
+Swap quotes and gasless trading — free to call.
+:::
+
+:::card{title="How x402 Works" href="../x402/how-it-works.md" icon="Zap"}
+The 402 response and on-chain settlement, end to end.
+:::
+
+::::

--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -13,19 +13,19 @@ LLMs have a knowledge cutoff. When an agent needs to answer "what happened last 
 
 Exa gives agents a live internet connection with structured, grounded results — not HTML soup, but clean text ready to feed into your next LLM call.
 
-**A complete research workflow costs $0.036:**
-- 1 search ($0.012) → find relevant URLs
-- 5 page reads ($0.012) → get full content
-- 1 synthesized answer ($0.012) → grounded conclusion
+**A complete research workflow costs $0.033:**
+- 1 search ($0.011) → find relevant URLs
+- 5 page reads in one call ($0.003/URL → $0.011) → get full content
+- 1 synthesized answer ($0.011) → grounded conclusion
 
 ## Endpoints
 
 | Endpoint | Method | Price | Description |
 |----------|--------|-------|-------------|
-| `/api/v1/exa/search` | POST | $0.012 | Neural web search — find relevant URLs for a query |
-| `/api/v1/exa/answer` | POST | $0.012 | Get a cited, synthesized answer to any question |
-| `/api/v1/exa/contents` | POST | $0.002/URL | Fetch full Markdown text from a list of URLs |
-| `/api/v1/exa/find-similar` | POST | $0.012 | Find pages similar to a given URL |
+| `/api/v1/exa/search` | POST | $0.011 | Neural web search — find relevant URLs for a query |
+| `/api/v1/exa/answer` | POST | $0.011 | Get a cited, synthesized answer to any question |
+| `/api/v1/exa/contents` | POST | $0.003/URL | Fetch full Markdown text from a list of URLs |
+| `/api/v1/exa/find-similar` | POST | $0.011 | Find pages similar to a given URL |
 
 ---
 
@@ -194,7 +194,7 @@ const analysis = await client.chat("anthropic/claude-opus-5", [
 
 ### 2. Fact-Checking Agent — No Hallucinations
 
-Agent needs a reliable answer to a factual question. Cost: $0.012.
+Agent needs a reliable answer to a factual question. Cost: $0.011.
 
 ```typescript
 const result = await client.exaAnswer(
@@ -207,7 +207,7 @@ console.log("Sources:", result.citations.map(c => c.url));
 
 ### 3. Competitive Intelligence — Find Similar Projects
 
-Discover what's being built in your space. Cost: $0.012.
+Discover what's being built in your space. Cost: $0.011.
 
 ```typescript
 const similar = await client.exaFindSimilar("https://blockrun.ai", {
@@ -235,7 +235,7 @@ const readmes = await client.exaContents([repos.results[0].url]);
 
 ### 5. Monitoring Agent — Track News About a Topic
 
-Weekly check on what's happening. Cost: $0.012/run.
+Weekly check on what's happening. Cost: $0.011/run.
 
 ```typescript
 const lastWeek = new Date();
@@ -317,9 +317,9 @@ const similar = await client.exaFindSimilar("https://blockrun.ai", { numResults:
 
 | Endpoint | Price per call |
 |----------|---------------|
-| `/exa/search` | $0.012 |
-| `/exa/answer` | $0.012 |
-| `/exa/find-similar` | $0.012 |
+| `/exa/search` | $0.011 |
+| `/exa/answer` | $0.011 |
+| `/exa/find-similar` | $0.011 |
 | `/exa/contents` | $0.002 per URL |
 
 Payment is in USDC on Base or Solana via x402. No account needed — your wallet is your identity.

--- a/docs/api-reference/market-data.md
+++ b/docs/api-reference/market-data.md
@@ -1,0 +1,127 @@
+---
+title: Market Data (Pyth)
+description: Spot prices and OHLC history for stocks, crypto, FX and commodities from Pyth Network — crypto, FX and commodities are free; equities are $0.0010 per call.
+---
+
+# Market Data (Pyth)
+
+Spot prices and historical OHLC bars across four asset classes, grounded in
+[Pyth Network](https://pyth.network) on-chain feeds.
+
+**Crypto, FX and commodity prices are free.** Equities — US and international —
+are `$0.0010` per call, because those feeds are broker-fed rather than
+open on-chain data. Every `/list` endpoint is free regardless of asset class.
+
+## Endpoints
+
+| Endpoint | Method | Price | Description |
+|----------|--------|-------|-------------|
+| `/api/v1/crypto/list` | GET | Free | Available crypto symbols |
+| `/api/v1/crypto/price/{symbol}` | GET | Free | Crypto spot price |
+| `/api/v1/crypto/history/{symbol}` | GET | Free | Crypto OHLC bars |
+| `/api/v1/fx/list` | GET | Free | Available FX pairs |
+| `/api/v1/fx/price/{symbol}` | GET | Free | FX spot rate |
+| `/api/v1/fx/history/{symbol}` | GET | Free | FX OHLC bars |
+| `/api/v1/commodity/list` | GET | Free | Available commodities |
+| `/api/v1/commodity/price/{symbol}` | GET | Free | Commodity spot price |
+| `/api/v1/commodity/history/{symbol}` | GET | Free | Commodity OHLC bars |
+| `/api/v1/usstock/list` | GET | Free | US tickers |
+| `/api/v1/usstock/price/{symbol}` | GET | $0.0010 | US equity spot price |
+| `/api/v1/usstock/history/{symbol}` | GET | $0.0010 | US equity OHLC bars |
+| `/api/v1/stocks/{market}/list` | GET | Free | Tickers for one non-US market |
+| `/api/v1/stocks/{market}/price/{symbol}` | GET | $0.0010 | Non-US equity spot price |
+| `/api/v1/stocks/{market}/history/{symbol}` | GET | $0.0010 | Non-US equity OHLC bars |
+
+`GET` and `POST` both work on every path; `POST` exists so callers that cannot
+attach headers to a `GET` still have a route.
+
+## Symbol formats
+
+Always resolve symbols from the matching `/list` endpoint rather than guessing.
+
+| Asset class | Format | Examples |
+|-------------|--------|----------|
+| Crypto | `BASE-QUOTE` | `BTC-USD`, `ETH-USD`, `SOL-USD` |
+| FX | `BASE-QUOTE` | `EUR-USD`, `GBP-USD`, `JPY-USD` |
+| Commodity | `METAL-USD` / ticker | `XAU-USD` (gold), `XAG-USD` (silver) |
+| US equity | Plain ticker | `AAPL`, `TSLA`, `NVDA`, `SPY` |
+| Non-US equity | Per-market convention | HKEX `-HK` suffix, TSE 4-digit, KRX 6-digit, LSE/XETRA/Euronext alpha |
+
+`/list` takes `q` (substring filter) and `limit` (max 2000, default 100).
+
+## Markets
+
+`{market}` for the `/stocks/` family: `us`, `hk`, `jp`, `kr`, `gb`, `de`, `fr`,
+`nl`, `ie`, `lu`, `cn`, `ca`. `/api/v1/usstock/*` is a legacy alias for
+`/api/v1/stocks/us/*` and behaves identically.
+
+---
+
+## Spot price
+
+```bash
+# Free — no payment header needed
+curl https://blockrun.ai/api/v1/crypto/price/BTC-USD
+
+# Paid — $0.0010
+curl https://blockrun.ai/api/v1/usstock/price/AAPL \
+  -H "X-Payment: <x402_payment_token>"
+```
+
+| Parameter | In | Required | Description |
+|-----------|----|----------|-------------|
+| `symbol` | path | Yes | Any symbol from the matching `/list` |
+| `session` | query | No | Trading session hint — `regular` or `extended` |
+
+The response carries `symbol`, `price`, `confidence` (Pyth's interval around
+the price), `publishTime` and `source`. Treat `confidence` as real: a wide
+interval means the feed is uncertain, not that the price is precise.
+
+---
+
+## OHLC history
+
+```bash
+curl "https://blockrun.ai/api/v1/crypto/history/BTC-USD?resolution=D&from=1735689600&to=1738368000"
+```
+
+| Parameter | In | Required | Description |
+|-----------|----|----------|-------------|
+| `symbol` | path | Yes | Any symbol from the matching `/list` |
+| `resolution` | query | No | Bar size — `1`, `5`, `15`, `60`, `240`, `D`, `W`, `M`. Default `D` |
+| `from` | query | No | Start, unix seconds |
+| `to` | query | No | End, unix seconds. Defaults to now |
+| `session` | query | No | `regular` or `extended` |
+
+---
+
+## Discovery
+
+Free endpoints still answer a `402` when you ask for one without payment — that
+response is x402 discovery metadata for indexers, not a charge. A plain `GET`
+returns `200` and the data.
+
+## Errors
+
+| Status | Meaning | Charged? |
+|--------|---------|----------|
+| `402` | Payment required (paid feeds), or discovery metadata (free feeds) | No |
+| `404` | Symbol not found — check the matching `/list` | No |
+
+## What's next?
+
+::::cards
+
+:::card{title="Surf — Crypto Data" href="surf.md" icon="ChartLine"}
+Exchange depth, liquidations, on-chain SQL and wallet labels.
+:::
+
+:::card{title="DefiLlama" href="defillama.md" icon="Landmark"}
+Protocol TVL, per-chain TVL and yield pools.
+:::
+
+:::card{title="Multi-chain RPC" href="multi-chain-rpc.md" icon="Link"}
+JSON-RPC to 40 chains through one endpoint.
+:::
+
+::::

--- a/docs/api-reference/modal-sandbox.md
+++ b/docs/api-reference/modal-sandbox.md
@@ -12,9 +12,9 @@ Secure code runtime for AI agents. Create a sandbox session, execute commands, i
 AI agents that need to run code face a dilemma: executing on the host is unsafe, and provisioning cloud VMs is slow and expensive. Modal Sandbox gives agents a safe execution layer they can call on demand, keep alive across multiple steps, and tear down when the job is finished.
 
 **A typical sandbox workflow costs $0.018:**
-- 1 sandbox create ($0.012) — boot a Python container
-- 1 exec ($0.003) — run the code
-- 1 terminate ($0.003) — clean up
+- 1 sandbox create ($0.011) — boot a Python container
+- 1 exec ($0.002) — run the code
+- 1 terminate ($0.002) — clean up
 
 :::warning{title="Public beta limits"}
 - Base only
@@ -27,10 +27,10 @@ AI agents that need to run code face a dilemma: executing on the host is unsafe,
 
 | Endpoint | Method | Price | Description |
 |----------|--------|-------|-------------|
-| `/api/v1/modal/sandbox/create` | POST | $0.012 | Create a managed sandbox session |
-| `/api/v1/modal/sandbox/exec` | POST | $0.003 | Execute a command inside a running sandbox |
-| `/api/v1/modal/sandbox/status` | POST | $0.003 | Check if a sandbox is running or terminated |
-| `/api/v1/modal/sandbox/terminate` | POST | $0.003 | Terminate a sandbox and release resources |
+| `/api/v1/modal/sandbox/create` | POST | $0.011 | Create a managed sandbox session |
+| `/api/v1/modal/sandbox/exec` | POST | $0.002 | Execute a command inside a running sandbox |
+| `/api/v1/modal/sandbox/status` | POST | $0.002 | Check if a sandbox is running or terminated |
+| `/api/v1/modal/sandbox/terminate` | POST | $0.002 | Terminate a sandbox and release resources |
 
 ---
 
@@ -149,7 +149,7 @@ curl -X POST https://blockrun.ai/api/v1/modal/sandbox/create \
 
 ::::steps
 
-:::step{title="Create the sandbox ($0.012)"}
+:::step{title="Create the sandbox ($0.011)"}
 ```bash
 curl -X POST https://blockrun.ai/api/v1/modal/sandbox/create \
   -H "Content-Type: application/json" \
@@ -158,7 +158,7 @@ curl -X POST https://blockrun.ai/api/v1/modal/sandbox/create \
 ```
 :::
 
-:::step{title="Execute code ($0.003)"}
+:::step{title="Execute code ($0.002)"}
 ```bash
 curl -X POST https://blockrun.ai/api/v1/modal/sandbox/exec \
   -H "Content-Type: application/json" \
@@ -167,7 +167,7 @@ curl -X POST https://blockrun.ai/api/v1/modal/sandbox/exec \
 ```
 :::
 
-:::step{title="Terminate ($0.003)"}
+:::step{title="Terminate ($0.002)"}
 ```bash
 curl -X POST https://blockrun.ai/api/v1/modal/sandbox/terminate \
   -H "Content-Type: application/json" \

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -225,7 +225,7 @@ Seedance defaults to **720p with synced audio** for text-to-video; pass `resolut
 | `bytedance/seedance-2.0` | Seedance 2.0 Pro | ~$0.319/sec ($1.59 / 5s clip) | 15s |
 | `azure/sora-2` | Sora 2 | $0.10/sec (4s = $0.42) | 12s |
 
-For character consistency across multiple Seedance videos, enroll a [Virtual Portrait](virtual-portrait.md) ($0.012 one-time, no KYC) for AI characters, or a [RealFace](realface.md) ($0.012 one-time, no KYC, requires brief on-phone liveness check) for real people. Pass the returned `ta_xxx` as `real_face_asset_id`.
+For character consistency across multiple Seedance videos, enroll a [Virtual Portrait](virtual-portrait.md) ($0.011 one-time, no KYC) for AI characters, or a [RealFace](realface.md) ($0.011 one-time, no KYC, requires brief on-phone liveness check) for real people. Pass the returned `ta_xxx` as `real_face_asset_id`.
 
 ## Model Categories
 

--- a/docs/api-reference/multi-chain-rpc.md
+++ b/docs/api-reference/multi-chain-rpc.md
@@ -1,11 +1,11 @@
 ---
 title: Multi-chain RPC
-description: Standard JSON-RPC 2.0 access to every supported blockchain through one endpoint, paid $0.004 per call in USDC over x402 — no account, no API key, no monthly plan.
+description: Standard JSON-RPC 2.0 access to every supported blockchain through one endpoint, paid $0.003 per call in USDC over x402 — no account, no API key, no monthly plan.
 ---
 
 # Multi-chain RPC — one endpoint, every chain
 
-Standard JSON-RPC 2.0 access to 40 blockchains through a single endpoint. No account, no API key, no monthly plan — pay **$0.004 per call** in USDC over x402. Built for AI agents that read on-chain data across many chains from one wallet.
+Standard JSON-RPC 2.0 access to 40 blockchains through a single endpoint. No account, no API key, no monthly plan — pay **$0.003 per call** in USDC over x402. Built for AI agents that read on-chain data across many chains from one wallet.
 
 BlockRun proxies upstream RPC gateways with x402 settlement, so an agent can query any supported chain without onboarding to a node provider.
 
@@ -21,10 +21,10 @@ POST /api/v1/rpc/{network}
 
 Swap `{network}` for the chain. Body is a standard JSON-RPC 2.0 request; the response is returned verbatim from the upstream node. EVM (`eth_*`) and non-EVM (`getSlot`, …) methods both work. A JSON-RPC **batch** (array body) is priced per element.
 
-**Flat price: $0.004 per call.** No payment header → HTTP 402 quoting the exact price; add an x402 payment header (a wallet signature) → the result, settled in USDC on Base. Hot reads are cached.
+**Flat price: $0.003 per call.** No payment header → HTTP 402 quoting the exact price; add an x402 payment header (a wallet signature) → the result, settled in USDC on Base. Hot reads are cached.
 
 :::info{title="402 quotes the price"}
-A request with no payment header returns `402 Payment Required` with the exact $0.004 quote and Base USDC instructions. Re-send with the `PAYMENT-SIGNATURE` header to get the result.
+A request with no payment header returns `402 Payment Required` with the exact $0.003 quote and Base USDC instructions. Re-send with the `PAYMENT-SIGNATURE` header to get the result.
 :::
 
 ## Supported networks (40+)
@@ -59,7 +59,7 @@ EVM and non-EVM, one path each. A selection:
 curl -X POST https://blockrun.ai/api/v1/rpc/ethereum \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}'
-# → 402 with price $0.0040 + Base USDC payment instructions
+# → 402 with price $0.0030 + Base USDC payment instructions
 # Re-send with the x402 PAYMENT-SIGNATURE header → {"jsonrpc":"2.0","id":1,"result":"0x..."}
 ```
 

--- a/docs/api-reference/polymarket-funding.md
+++ b/docs/api-reference/polymarket-funding.md
@@ -18,14 +18,14 @@ Pairs with `blockrun_polymarket action:"fund"` in [BlockRun MCP](../mcp/blockrun
 The agent signs **two** EIP-3009 (`transferWithAuthorization`) USDC authorizations and sends both in one request:
 
 1. **Deposit** — the agent's USDC → the Polymarket bridge address for its vault.
-2. **Fee** — `$0.012` USDC → the BlockRun treasury (the standard x402 payment).
+2. **Fee** — `$0.011` USDC → the BlockRun treasury (the standard x402 payment).
 
 BlockRun then:
 
-1. Verifies the `$0.012` fee authorization and guards it against replay.
+1. Verifies the `$0.011` fee authorization and guards it against replay.
 2. **Validates** that `recipient` really is the Polymarket bridge deposit address for the caller's `depositWallet` (live lookup against the bridge). A mismatch is rejected before any settlement.
 3. Hands the **deposit** authorization to the CDP facilitator, which broadcasts it and **pays the gas**. The USDC settles **directly to the bridge** — BlockRun is never in the flow of funds.
-4. Only after the deposit is confirmed on-chain does BlockRun charge the `$0.012` fee.
+4. Only after the deposit is confirmed on-chain does BlockRun charge the `$0.011` fee.
 5. The Polymarket bridge wraps the USDC → **pUSD** and credits the agent's vault on **Polygon**.
 
 **A deposit that does not confirm is never billed.** The fee is charged only after the deposit settles on-chain.
@@ -40,13 +40,13 @@ This call is **cross-chain**: you sign and move **USDC on Base**, and it lands a
 | Deposit authorization (what you sign) | Base | USDC → Polymarket bridge |
 | Vault destination (where it arrives) | Polygon | pUSD |
 
-Both authorizations you sign — the `$0.012` fee and the deposit — are **Base USDC**; you never touch Polygon or hold Base ETH for gas. The Polymarket bridge wraps the deposited USDC to **pUSD** and credits your vault on Polygon.
+Both authorizations you sign — the `$0.011` fee and the deposit — are **Base USDC**; you never touch Polygon or hold Base ETH for gas. The Polymarket bridge wraps the deposited USDC to **pUSD** and credits your vault on Polygon.
 
 ## Pricing
 
 | Item | Amount | Paid to |
 |------|--------|---------|
-| Service fee | `$0.012` (`POLYMARKET_FUND_FEE_USD`) | BlockRun treasury (x402) |
+| Service fee | `$0.011` (`POLYMARKET_FUND_FEE_USD`) | BlockRun treasury (x402) |
 | Gas | Sponsored by BlockRun | — |
 | Deposit principal | Your chosen amount | Polymarket bridge (non-custodial) |
 
@@ -65,7 +65,7 @@ Maximum deposit per call: `$10,000` (`POLYMARKET_FUND_MAX_USD`).
 | `amountMicro` | string | ✅ | Deposit amount in **micro-USDC** (6 decimals) as a canonical integer string, e.g. `"25000000"` for `$25`. **Must exactly equal the `value` in your signed deposit authorization.** |
 | `depositAuthorization` | string | ✅ | Base64 x402 payload: your EIP-3009 signed USDC transfer of `amountMicro` to `recipient`. |
 
-The `$0.012` fee authorization travels in the standard `X-Payment` header, exactly like every other paid BlockRun endpoint.
+The `$0.011` fee authorization travels in the standard `X-Payment` header, exactly like every other paid BlockRun endpoint.
 
 ### Discovery (402)
 
@@ -107,7 +107,7 @@ curl -X POST https://blockrun.ai/api/v1/polymarket/fund
 The confirmed deposit transaction hash is also returned in the `X-Deposit-Tx` response header; the fee receipt is in `X-Payment-Receipt`.
 
 :::warning Settlement is asynchronous
-`success: true` means the deposit was **submitted to the bridge and confirmed on Base** — and the `$0.012` fee charged. It does **not** mean your vault is funded yet: `funded` is `false` and `creditPending` is `true`. The Polymarket bridge credits **pUSD on Polygon** off-chain and asynchronously — usually within minutes, occasionally **30+ minutes**. There is no on-chain bridge message to poll; check your Polygon vault's pUSD balance until it lands. Very small deposits and non-standard deposit wallets may take longer or require a real (setup-derived) vault.
+`success: true` means the deposit was **submitted to the bridge and confirmed on Base** — and the `$0.011` fee charged. It does **not** mean your vault is funded yet: `funded` is `false` and `creditPending` is `true`. The Polymarket bridge credits **pUSD on Polygon** off-chain and asynchronously — usually within minutes, occasionally **30+ minutes**. There is no on-chain bridge message to poll; check your Polygon vault's pUSD balance until it lands. Very small deposits and non-standard deposit wallets may take longer or require a real (setup-derived) vault.
 :::
 
 ### Errors
@@ -126,7 +126,7 @@ Every non-2xx response that could otherwise be ambiguous states explicitly wheth
 
 ```bash
 curl -X POST https://blockrun.ai/api/v1/polymarket/fund \
-  -H "X-Payment: <base64 signed $0.012 fee authorization>" \
+  -H "X-Payment: <base64 signed $0.011 fee authorization>" \
   -H "Content-Type: application/json" \
   -d '{
     "depositWallet": "0xYourVaultOwner…",

--- a/docs/api-reference/prediction-markets.md
+++ b/docs/api-reference/prediction-markets.md
@@ -1,13 +1,13 @@
 ---
 title: Prediction Markets API
-description: Real-time prediction market data across Polymarket, Kalshi, and more — plus wallet identity, clustering, and sports markets, paid per call in USDC over x402.
+description: Real-time prediction market data across Polymarket, Kalshi, and more — plus wallet identity and clustering, paid per call in USDC over x402.
 ---
 
 # Prediction Markets API
 
 Access real-time prediction market data via x402 micropayments. Powered by [Predexon](https://predexon.com).
 
-Unified access to Polymarket, Kalshi, dFlow, Binance, Limitless, Opinion, Predict.Fun, sports markets, plus UMA Oracle resolution data, canonical cross-venue market IDs, and on-chain wallet identity & clustering — all through a single API.
+Unified access to Polymarket, Kalshi, Binance, Limitless, Opinion and Predict.Fun, plus UMA Oracle resolution data and on-chain wallet identity & clustering — all through a single API.
 
 :::note
 Mirrors the Predexon **v2 Data API** (`docs.predexon.com/openapi-v2.json`) — read-only market data. To move funds, see the [Polymarket Funding API](polymarket-funding.md) (gasless, non-custodial deposit). Predexon's separate order-placement Trading API is not exposed.
@@ -24,14 +24,14 @@ Mirrors the Predexon **v2 Data API** (`docs.predexon.com/openapi-v2.json`) — r
 
 | Tier | Price | Use Case |
 |------|-------|----------|
-| Tier 1 | $0.0095 | Market data, events, trades, orderbooks, positions, leaderboards, sports markets, canonical cross-venue markets |
-| Tier 2 | $0.0095 | Wallet analytics (incl. identity + clustering), smart money, cross-platform matching, Binance data |
+| Tier 1 | $0.0085 | Market data, events, trades, orderbooks, positions, leaderboards |
+| Tier 2 | $0.0085 | Wallet analytics (incl. identity + clustering), smart money, cross-venue search, Binance data |
 
 ---
 
 ## Endpoints
 
-### Polymarket — Market Data (Tier 1: $0.0095)
+### Polymarket — Market Data (Tier 1: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -51,7 +51,7 @@ Mirrors the Predexon **v2 Data API** (`docs.predexon.com/openapi-v2.json`) — r
 | `/api/v1/pm/polymarket/markets/{condition_id}/open_interest` | GET | Get historical open interest |
 | `/api/v1/pm/polymarket/positions` | GET | Fetch all user positions |
 
-### Polymarket — Analytics (Tier 1: $0.0095)
+### Polymarket — Analytics (Tier 1: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -60,7 +60,7 @@ Mirrors the Predexon **v2 Data API** (`docs.predexon.com/openapi-v2.json`) — r
 | `/api/v1/pm/polymarket/cohorts/stats` | GET | Compare performance across trading style cohorts |
 | `/api/v1/pm/polymarket/market/{condition_id}/top-holders` | GET | Top holders ranked by position size |
 
-### Polymarket — Wallet Analytics (Tier 2: $0.0095)
+### Polymarket — Wallet Analytics (Tier 2: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -73,21 +73,21 @@ Mirrors the Predexon **v2 Data API** (`docs.predexon.com/openapi-v2.json`) — r
 | `/api/v1/pm/polymarket/wallets/profiles` | GET | Batch wallet profiles (max 20) |
 | `/api/v1/pm/polymarket/wallets/filter` | GET | Filter wallets by market trades |
 
-### Polymarket — Smart Money (Tier 2: $0.0095)
+### Polymarket — Smart Money (Tier 2: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/v1/pm/polymarket/market/{condition_id}/smart-money` | GET | Smart money positioning on a market |
 | `/api/v1/pm/polymarket/markets/smart-activity` | GET | Markets where top wallets are active |
 
-### UMA Oracle — Polymarket Resolution (Tier 1: $0.0095)
+### UMA Oracle — Polymarket Resolution (Tier 1: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/v1/pm/polymarket/uma/markets` | GET | List UMA oracle questions filtered by state (proposed, disputed, resolved, …) |
 | `/api/v1/pm/polymarket/uma/market/{condition_id}` | GET | Current UMA oracle status and event timeline for a single market |
 
-### Wallet Identity & Clustering (Tier 2: $0.0095)
+### Wallet Identity & Clustering (Tier 2: $0.0085)
 
 Cross-context wallet labels and on-chain relationship graph data.
 
@@ -97,7 +97,7 @@ Cross-context wallet labels and on-chain relationship graph data.
 | `/api/v1/pm/polymarket/wallet/identities` | POST | Bulk identity lookup — body `{"addresses":[...]}` (up to 200 addresses) |
 | `/api/v1/pm/polymarket/wallet/{address}/cluster` | GET | Wallets connected to a seed address via on-chain transfers and identity proofs |
 
-### Kalshi (Tier 1: $0.0095)
+### Kalshi (Tier 1: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -105,49 +105,32 @@ Cross-context wallet labels and on-chain relationship graph data.
 | `/api/v1/pm/kalshi/trades` | GET | Fetch historical trade data |
 | `/api/v1/pm/kalshi/orderbooks` | GET | Fetch historical orderbook snapshots |
 
-### dFlow
-
-| Endpoint | Method | Price | Description |
-|----------|--------|-------|-------------|
-| `/api/v1/pm/dflow/trades` | GET | $0.0095 | Fetch trade history for a wallet |
-| `/api/v1/pm/dflow/wallet/positions/{wallet}` | GET | $0.0095 | Current positions for a wallet |
-| `/api/v1/pm/dflow/wallet/pnl/{wallet}` | GET | $0.0095 | Realized P&L history for a wallet |
-
-### Binance (Tier 2: $0.0095)
+### Binance (Tier 2: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/v1/pm/binance/candles/{symbol}` | GET | OHLCV candlestick data (BTCUSDT, ETHUSDT, SOLUSDT, XRPUSDT) |
 | `/api/v1/pm/binance/ticks/{symbol}` | GET | Raw book ticker data at microsecond granularity |
 
-### Cross-Venue Canonical Markets (Tier 1: $0.0095)
-
-Predexon v2 unified data layer — canonical Predexon IDs across all venues.
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v1/pm/markets` | GET | List canonical market/question containers with cross-venue Predexon IDs |
-| `/api/v1/pm/markets/listings` | GET | List venue-native executable listings flattened across canonical markets |
-| `/api/v1/pm/outcomes/{predexon_id}` | GET | Resolve a canonical Predexon outcome ID to its market context and venue listings |
-
-### Cross-Platform Search (Tier 2: $0.0095)
+### Cross-Platform Search (Tier 2: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/v1/pm/markets/search` | GET | Search markets across Polymarket, Kalshi, Limitless, Opinion, and Predict.Fun in a single call |
 
-> `matching-markets` and `matching-markets/pairs` were retired on 2026-07-20 (upstream discontinued market matching). Use the canonical `markets` / `markets/listings` endpoints for cross-venue equivalence.
+> **Retired 2026-07-20.** Predexon discontinued market matching, and the whole
+> canonical layer went with it: `matching-markets`, `matching-markets/pairs`,
+> `markets`, `markets/listings` and `outcomes/{predexon_id}` all return `410`.
+> `markets/search` above is the surviving cross-venue endpoint.
 
-### Sports Markets (Tier 1: $0.0095)
+### Sports Markets — temporarily unavailable
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v1/pm/sports/categories` | GET | List available sports categories, sports, and leagues |
-| `/api/v1/pm/sports/markets` | GET | List sports markets grouped by game (filter by `sport`, `league`, `game_date`, etc.) |
-| `/api/v1/pm/sports/markets/{game_id}` | GET | Get a single sports game with all venue outcomes |
-| `/api/v1/pm/sports/outcomes/{predexon_id}` | GET | Find all equivalent sports outcomes across venues for a Predexon ID |
+`/api/v1/pm/sports/*` is returning an upstream `500` as of 2026-08-04 and is
+withheld from discovery until Predexon restores it. The routes still resolve, so
+existing integrations keep working the moment upstream recovers; new ones should
+not build on it yet.
 
-### Other Platforms (Tier 1: $0.0095)
+### Other Platforms (Tier 1: $0.0085)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -279,18 +262,19 @@ curl -X POST "https://blockrun.ai/api/v1/pm/polymarket/wallet/identities" \
 
 ---
 
-## Example: Sports Markets
+## Example: Cross-Venue Search
 
 ```
-GET https://blockrun.ai/api/v1/pm/sports/markets
+GET https://blockrun.ai/api/v1/pm/markets/search
 ```
 
 ```bash
-curl "https://blockrun.ai/api/v1/pm/sports/markets?league=mlb&status=open&limit=10"
-curl "https://blockrun.ai/api/v1/pm/sports/markets/mlb-laa-nym-2026-05-02"
+curl "https://blockrun.ai/api/v1/pm/markets/search?q=bitcoin%202026"
+curl "https://blockrun.ai/api/v1/pm/markets/search?q=election&platform=kalshi"
 ```
 
-Returns sports games grouped with all venue outcomes (Kalshi, Polymarket, etc.) attached.
+Searches Polymarket, Kalshi, Limitless, Opinion and Predict.Fun in one call.
+`q` is required — omitting it returns `422`.
 
 ---
 
@@ -304,32 +288,28 @@ from blockrun_llm import LLMClient
 
 client = LLMClient()
 
-# Market data ($0.0095)
+# Market data ($0.0085)
 markets = client.pm("polymarket/markets", search="bitcoin", limit=10)
 events = client.pm("polymarket/events")
 trades = client.pm("kalshi/trades")
 
-# Wallet analytics ($0.0095)
+# Wallet analytics ($0.0085)
 profile = client.pm("polymarket/wallet/0x1234...abcd")
 pnl = client.pm("polymarket/wallet/pnl/0x1234...abcd")
 
-# Canonical cross-venue markets ($0.0095)
-canonical = client.pm("markets", venue="polymarket", limit=20)
-listings = client.pm("markets/listings", league="mlb")
+# Cross-venue search ($0.0085)
+found = client.pm("markets/search", q="bitcoin 2026")
 
-# Sports ($0.0095)
-games = client.pm("sports/markets", league="mlb", status="open")
-
-# Wallet identity (single, $0.0095)
+# Wallet identity (single, $0.0085)
 identity = client.pm("polymarket/wallet/identity/0x1234...abcd")
 
-# Wallet identity (bulk, POST, $0.0095)
+# Wallet identity (bulk, POST, $0.0085)
 identities = client.pm_query(
     "polymarket/wallet/identities",
     {"addresses": ["0x1234...abcd", "0x5678...ef01"]},
 )
 
-# Binance ($0.0095)
+# Binance ($0.0085)
 candles = client.pm("binance/candles/BTCUSDT", interval="1h", limit=24)
 ```
 :::
@@ -340,24 +320,23 @@ import { LLMClient } from "blockrun-llm";
 
 const client = new LLMClient();
 
-// Market data ($0.0095)
+// Market data ($0.0085)
 const markets = await client.pm("polymarket/markets", { search: "bitcoin", limit: "10" });
 const events = await client.pm("polymarket/events");
 
-// Wallet analytics ($0.0095)
+// Wallet analytics ($0.0085)
 const profile = await client.pm("polymarket/wallet/0x1234...abcd");
 const identity = await client.pm("polymarket/wallet/identity/0x1234...abcd");
 
-// Bulk wallet identity (POST, $0.0095)
+// Bulk wallet identity (POST, $0.0085)
 const identities = await client.pmQuery("polymarket/wallet/identities", {
   addresses: ["0x1234...abcd", "0x5678...ef01"],
 });
 
-// Canonical cross-venue markets + sports ($0.0095)
-const canonical = await client.pm("markets", { venue: "polymarket", limit: "20" });
-const games = await client.pm("sports/markets", { league: "mlb", status: "open" });
+// Cross-venue search ($0.0085)
+const found = await client.pm("markets/search", { q: "bitcoin 2026" });
 
-// Binance ($0.0095)
+// Binance ($0.0085)
 const candles = await client.pm("binance/candles/BTCUSDT", { interval: "1h", limit: "24" });
 ```
 :::

--- a/docs/api-reference/realface.md
+++ b/docs/api-reference/realface.md
@@ -8,18 +8,18 @@ description: Enroll a real person's face (no KYC, ~1-min on-phone liveness) as a
 Enroll a real person's face as a `ta_xxxxxxxx` asset you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0-fast call. Use this when you want **a real person to appear consistently across multiple videos** (talking head, spokesperson, character continuity).
 
 :::note{title="No KYC required"}
-No government ID, no account login, no name verification. Just a brief on-phone liveness check (nod + blink, ~1 minute) that proves the person enrolling is the same as the person in the photo. The biometric data is processed by the upstream identity service — BlockRun never sees it. For purely AI-generated characters (no real person involved), use [Virtual Portrait](virtual-portrait.md) instead ($0.012, no liveness step).
+No government ID, no account login, no name verification. Just a brief on-phone liveness check (nod + blink, ~1 minute) that proves the person enrolling is the same as the person in the photo. The biometric data is processed by the upstream identity service — BlockRun never sees it. For purely AI-generated characters (no real person involved), use [Virtual Portrait](virtual-portrait.md) instead ($0.011, no liveness step).
 :::
 
 | | |
 |---|---|
-| **Endpoints** | `POST /v1/realface/init` (free, returns h5Link) · `POST /v1/realface/enroll` ($0.012 USDC, finalizes) · `GET /v1/realface/status?groupId=…` (free polling) |
-| **Price** | **$0.012 USDC** per enrollment, one-time, settled to BlockRun's Base wallet via x402 |
+| **Endpoints** | `POST /v1/realface/init` (free, returns h5Link) · `POST /v1/realface/enroll` ($0.011 USDC, finalizes) · `GET /v1/realface/status?groupId=…` (free polling) |
+| **Price** | **$0.011 USDC** per enrollment, one-time, settled to BlockRun's Base wallet via x402 |
 | **Auth** | x402 micropayment header on finalize — no API key needed |
 | **Network** | Base (USDC, EIP-3009 `exact`) |
 | **Returns** | `ta_xxxxxxxx…` asset id, usable as `real_face_asset_id` on Seedance 2.0 / 2.0-fast |
 
-You can use the web UI at [blockrun.ai/studio/realface](https://blockrun.ai/studio/realface) — connect wallet, paste image URL, get QR for the rights-holder to scan, pay $0.012, copy the `ta_xxx`. The endpoints below are for SDK / programmatic use.
+You can use the web UI at [blockrun.ai/studio/realface](https://blockrun.ai/studio/realface) — connect wallet, paste image URL, get QR for the rights-holder to scan, pay $0.011, copy the `ta_xxx`. The endpoints below are for SDK / programmatic use.
 
 ## Flow
 
@@ -40,7 +40,7 @@ You can use the web UI at [blockrun.ai/studio/realface](https://blockrun.ai/stud
     →    ... (after H5 completes)
     →    { status: "active", ready_to_finalize: true }
 
-[4] POST /v1/realface/enroll                     — PAID ($0.012 USDC)
+[4] POST /v1/realface/enroll                     — PAID ($0.011 USDC)
     body: { "name": "...", "image_url": "https://...", "group_id": "..." }
     headers: { "x-payment": "<x402 base64>" }
     →    { asset_id: "ta_…", group_id: "...", ... }
@@ -156,7 +156,7 @@ When `status` transitions to `"active"` (and `ready_to_finalize: true`), the rig
 Poll every 3-5 seconds. Free but rate-limited (same bucket as wallet reconciliation, 20/hour/IP).
 :::
 
-:::step{title="Finalize (PAID, $0.012 USDC)"}
+:::step{title="Finalize (PAID, $0.011 USDC)"}
 
 ```
 POST https://blockrun.ai/api/v1/realface/enroll
@@ -183,7 +183,7 @@ POST https://blockrun.ai/api/v1/realface/enroll
 Same two-step pattern as other paid BlockRun endpoints:
 
 1. First call without `X-Payment` → server returns `402 Payment Required` with x402 challenge headers
-2. Sign the EIP-3009 transfer authorization for **$0.012 USDC on Base**
+2. Sign the EIP-3009 transfer authorization for **$0.011 USDC on Base**
 3. Retry the same request with `X-Payment: <base64>`
 
 Settlement happens **after** the upstream face-match succeeds. Failure modes that do NOT settle:
@@ -289,7 +289,7 @@ The video playground reads this same list and shows it in the `real_face_asset_i
 | | Virtual Portrait | RealFace |
 |---|---|---|
 | Asset target | AI-generated character | Real person |
-| Price | $0.012 USDC | $0.012 USDC |
+| Price | $0.011 USDC | $0.011 USDC |
 | Liveness check | Not required | Required (~1 minute on phone) |
 | Upstream verification | None | Biometric match against H5 live face |
 | KYC / government ID | Not required | Not required |
@@ -304,7 +304,7 @@ Pass the `ta_xxx` you just enrolled as `real_face_asset_id` on a Seedance 2.0 / 
 :::
 
 :::card{title="Virtual Portrait" href="virtual-portrait.md" icon="Boxes"}
-The zero-liveness option for AI-generated characters — same `ta_xxx` mechanic, $0.012.
+The zero-liveness option for AI-generated characters — same `ta_xxx` mechanic, $0.011.
 :::
 
 :::card{title="x402 Payment Flow" href="../x402/payment-flow.md" icon="Zap"}

--- a/docs/api-reference/surf.md
+++ b/docs/api-reference/surf.md
@@ -21,9 +21,9 @@ Surf unifies all of it behind one schema, billed per-call in stablecoins. An age
 
 | Tier | Price | Use case |
 |------|-------|----------|
-| Tier 1 | **$0.0095 / call** | Simple lookups (prices, rankings, indices) |
-| Tier 2 | **$0.0095 / call** | Time-series, technical indicators, orderbook depth |
-| Tier 3 | **$0.0095 / call** | On-chain SQL — raw queries against 80+ ClickHouse tables |
+| Tier 1 | **$0.0085 / call** | Simple lookups (prices, rankings, indices) |
+| Tier 2 | **$0.0085 / call** | Time-series, technical indicators, orderbook depth |
+| Tier 3 | **$0.0085 / call** | On-chain SQL — raw queries against 80+ ClickHouse tables |
 
 ### Categories
 
@@ -60,7 +60,7 @@ Method follows the upstream — most are `GET` with query string params; the two
 
 ## Examples
 
-### Spot price lookup (Tier 1 — $0.0095)
+### Spot price lookup (Tier 1 — $0.0085)
 
 ```bash
 curl "https://blockrun.ai/api/v1/surf/market/price?symbol=BTC"
@@ -79,14 +79,14 @@ curl -H "X-Payment: <signed>" \
   "https://blockrun.ai/api/v1/surf/market/fear-greed"
 ```
 
-### Perpetual funding history (Tier 2 — $0.0095)
+### Perpetual funding history (Tier 2 — $0.0085)
 
 ```bash
 curl -H "X-Payment: <signed>" \
   "https://blockrun.ai/api/v1/surf/exchange/funding-history?pair=BTC-USDT-PERP"
 ```
 
-### Raw on-chain SQL (Tier 3 — $0.0095)
+### Raw on-chain SQL (Tier 3 — $0.0085)
 
 ```bash
 curl -X POST \
@@ -164,9 +164,9 @@ The `blockrun_surf` MCP tool ships with [BlockRun MCP](../mcp/blockrun-mcp.md). 
 
 ```typescript
 const [price, fng, funding] = await Promise.all([
-  client.surf('GET', 'market/price', { symbol: 'BTC' }),       // $0.0095
-  client.surf('GET', 'market/fear-greed'),                      // $0.0095
-  client.surf('GET', 'exchange/funding-history', { pair: 'BTC-USDT-PERP' }), // $0.0095
+  client.surf('GET', 'market/price', { symbol: 'BTC' }),       // $0.0085
+  client.surf('GET', 'market/fear-greed'),                      // $0.0085
+  client.surf('GET', 'exchange/funding-history', { pair: 'BTC-USDT-PERP' }), // $0.0085
 ]);
 ```
 
@@ -181,7 +181,7 @@ positions = client.surf('GET', 'prediction-market/polymarket/positions', {'addre
 
 Pipe into an LLM to summarize: *"Wallet X (smart-money DeFi whale) opened a $200K Polymarket position on the Fed Dec rate cut."*
 
-### 3. On-chain SQL for research reports ($0.0095/query)
+### 3. On-chain SQL for research reports ($0.0085/query)
 
 ```sql
 -- "Which Base contracts grew most in unique users last week?"
@@ -195,7 +195,7 @@ LIMIT 20
 
 A weekly research bot that runs this twice and feeds the result into Claude Opus to write a 1-page narrative costs ~$0.044 + LLM tokens.
 
-### 4. Multi-source prediction-market aggregator (Tier 1, ~$0.0095/event)
+### 4. Multi-source prediction-market aggregator (Tier 1, ~$0.0085/event)
 
 ```python
 poly = client.surf('GET', 'prediction-market/polymarket/markets', {'market_slug': slug})
@@ -223,9 +223,9 @@ Common required params:
 
 | Tier | Price | Endpoints in tier |
 |------|-------|-------------------|
-| Tier 1 | $0.0095 | 44 (basic lookups, rankings, snapshots) |
-| Tier 2 | $0.0095 | 36 (time-series, indicators, depth, history) |
-| Tier 3 | $0.0095 | 3 (`onchain/sql`, `onchain/query`, `onchain/schema`) |
+| Tier 1 | $0.0085 | 44 (basic lookups, rankings, snapshots) |
+| Tier 2 | $0.0085 | 36 (time-series, indicators, depth, history) |
+| Tier 3 | $0.0085 | 3 (`onchain/sql`, `onchain/query`, `onchain/schema`) |
 
 Payment is in USDC on Base or Solana via x402. **Settles 1:1 directly to Surf's treasury wallet** (`0x058a5961FbE8cD8E4B47C69d3d82E159cb5d8F17` on Base) — BlockRun takes no margin. We pass through pricing as-is in exchange for being the discovery/auth/settlement layer.
 
@@ -239,7 +239,7 @@ Payment is in USDC on Base or Solana via x402. **Settles 1:1 directly to Surf's 
 | Account required | No | Yes | Yes | Yes |
 | Works for autonomous agents | ✅ | ❌ (API key, KYC) | ❌ | ❌ |
 | Coverage | 83 endpoints across 12 categories | Same upstream | Prices only | SQL only |
-| On-chain SQL | ✅ ($0.0095/query) | ✅ | ❌ | ✅ ($$$) |
+| On-chain SQL | ✅ ($0.0085/query) | ✅ | ❌ | ✅ ($$$) |
 | Same wallet as LLM calls | ✅ | N/A | N/A | N/A |
 
 ---

--- a/docs/api-reference/text-to-speech.md
+++ b/docs/api-reference/text-to-speech.md
@@ -113,7 +113,7 @@ POST /api/v1/audio/sound-effects
 | `prompt_influence` | number | No | 0–1, how strictly to follow the prompt |
 | `response_format` | string | No | `mp3` (default), `opus`, `pcm`, `wav` |
 
-Flat price: **$0.052 / generation** (+5% fee).
+Flat price: **$0.0535 / generation** ($0.05 base + 5% margin + the $0.001 transaction fee).
 
 ## Voices (free)
 

--- a/docs/api-reference/video-generation.md
+++ b/docs/api-reference/video-generation.md
@@ -86,8 +86,8 @@ Notes:
 Whether you can seed generation from an image — and how — depends on the subject:
 
 - **Non-human subject** (product, scene, animal, object): pass `image_url` (a public URL to the first frame) on **`azure/sora-2`**, **Grok**, or any **Seedance** model. For `azure/sora-2` the gateway resizes the seed image server-side to Sora's exact required dimensions (1280×720 / 720×1280). Seedance image-to-video is billed at the same per-token rate as text-to-video.
-- **A specific real person**: you cannot upload a face to Sora (see the note below). Use **Seedance 2.0 / 2.0-fast + a RealFace `ta_xxxx` asset** — enroll the person once *with their consent* ([RealFace](realface.md), ~1-min on-phone liveness, $0.012), then pass `real_face_asset_id`. Details in [Character consistency](#character-consistency-seedance-20-fast--pro) below.
-- **An AI character / mascot**: same flow with a [Virtual Portrait](virtual-portrait.md) asset (no KYC, $0.012).
+- **A specific real person**: you cannot upload a face to Sora (see the note below). Use **Seedance 2.0 / 2.0-fast + a RealFace `ta_xxxx` asset** — enroll the person once *with their consent* ([RealFace](realface.md), ~1-min on-phone liveness, $0.011), then pass `real_face_asset_id`. Details in [Character consistency](#character-consistency-seedance-20-fast--pro) below.
+- **An AI character / mascot**: same flow with a [Virtual Portrait](virtual-portrait.md) asset (no KYC, $0.011).
 
 :::warning{title="Sora reference images cannot contain human faces"}
 `azure/sora-2` **rejects reference images that contain human faces** — a moderation pipeline blocks any recognizable person to prevent deepfakes, and there is no general human-likeness image-upload path. So on BlockRun: **`azure/sora-2` does image-to-video for non-human subjects** (`image_url`, resized server-side to Sora's exact dimensions); and **real-person video goes through Seedance 2.0 + RealFace** (the consent-based route above).
@@ -136,8 +136,8 @@ All prices include the gateway's standard **5% margin** — i.e. these are the a
 
 | Action | Endpoint | Price |
 |---|---|---|
-| Virtual Portrait enrollment | [`POST /v1/portrait/enroll`](virtual-portrait.md) | $0.012 USDC per asset (no KYC) |
-| RealFace enrollment | [`POST /v1/realface/enroll`](realface.md) | $0.012 USDC per asset (no KYC, requires ~1-min on-phone liveness) |
+| Virtual Portrait enrollment | [`POST /v1/portrait/enroll`](virtual-portrait.md) | $0.011 USDC per asset (no KYC) |
+| RealFace enrollment | [`POST /v1/realface/enroll`](realface.md) | $0.011 USDC per asset (no KYC, requires ~1-min on-phone liveness) |
 
 ---
 
@@ -314,8 +314,8 @@ Pass a `ta_xxxx` asset from a Virtual Portrait or RealFace enrollment to keep th
 
 | Asset type | Use when | KYC? | Liveness? | Cost | Enroll via |
 |---|---|---|---|---|---|
-| [**Virtual Portrait**](virtual-portrait.md) | AI character, mascot, avatar | No | No | $0.012 USDC | [`POST /v1/portrait/enroll`](virtual-portrait.md) · [studio/portrait](https://blockrun.ai/studio/portrait) |
-| [**RealFace**](realface.md) | Real person you have rights to | No | Yes (~1 min on phone) | $0.012 USDC (promo) | [`POST /v1/realface/init`](realface.md) + `/enroll` · [studio/realface](https://blockrun.ai/studio/realface) |
+| [**Virtual Portrait**](virtual-portrait.md) | AI character, mascot, avatar | No | No | $0.011 USDC | [`POST /v1/portrait/enroll`](virtual-portrait.md) · [studio/portrait](https://blockrun.ai/studio/portrait) |
+| [**RealFace**](realface.md) | Real person you have rights to | No | Yes (~1 min on phone) | $0.011 USDC (promo) | [`POST /v1/realface/init`](realface.md) + `/enroll` · [studio/realface](https://blockrun.ai/studio/realface) |
 
 ---
 

--- a/docs/api-reference/virtual-portrait.md
+++ b/docs/api-reference/virtual-portrait.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Portrait Enrollment
-description: Enroll an AI-generated character (no KYC, no liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0-fast videos — $0.012 USDC.
+description: Enroll an AI-generated character (no KYC, no liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0-fast videos — $0.011 USDC.
 ---
 
 # Virtual Portrait Enrollment
@@ -14,7 +14,7 @@ Use this for AI-generated personas, mascots, avatars, virtual spokespeople — n
 | | |
 |---|---|
 | **Endpoint** | `POST https://blockrun.ai/api/v1/portrait/enroll` |
-| **Price** | **$0.012 USDC** per enrollment (one-time, settled to BlockRun's Base wallet via x402) |
+| **Price** | **$0.011 USDC** per enrollment (one-time, settled to BlockRun's Base wallet via x402) |
 | **Auth** | x402 micropayment header — no API key needed |
 | **Network** | Base (USDC, EIP-3009 `exact`) |
 | **Returns** | `ta_xxxxxxxx…` asset id for use with `real_face_asset_id` on Seedance 2.0 / 2.0-fast |
@@ -52,7 +52,7 @@ Images that fail the upstream content filter (NSFW, recognizable real-celebrity 
 Standard BlockRun two-step:
 
 1. **First request without `X-Payment`** → server returns `402 Payment Required` with x402 challenge headers
-2. Sign the EIP-3009 transfer authorization for **$0.012 USDC on Base**
+2. Sign the EIP-3009 transfer authorization for **$0.011 USDC on Base**
 3. **Retry the same request with `X-Payment: <base64>`** → server verifies, registers the portrait, settles the payment after registration succeeds, returns the `ta_xxx`
 
 Settlement happens **after** the portrait is successfully enrolled. If enrollment fails (content filter, network error), no payment is taken — the route returns 502 and the caller can retry with a fresh signature. If settlement itself fails after a successful enrollment, BlockRun absorbs the cost rather than leave the user with a paid-but-unrecoverable state.

--- a/docs/api-reference/voice-phone.md
+++ b/docs/api-reference/voice-phone.md
@@ -1,6 +1,6 @@
 ---
 title: Phone & Voice
-description: Outbound AI voice calls and wallet-owned phone numbers for agents — $5 per number (30 days), $0.542 flat per call, no telecom account.
+description: Outbound AI voice calls and wallet-owned phone numbers for agents — $5 per number (30 days), $0.541 flat per call, no telecom account.
 ---
 
 # Phone & Voice
@@ -10,7 +10,7 @@ Outbound AI voice calls and wallet-owned phone numbers — for AI agents. No tel
 **Default country:** US (no regulatory friction). Other countries can be requested via the `country` parameter — see [Country availability](#country-availability) below.
 
 :::info{title="Costs"}
-A number is **$5 / 30 days** (renew for $5). Each outbound call is **$0.542 flat** (up to 30 min, default 5). Polling status / fetching a transcript is **free**. Failed call legs (`ended_by: ERROR`) and 429/502 upstream errors are **not charged**. All settled in USDC on Base or Solana via x402.
+A number is **$5 / 30 days** (renew for $5). Each outbound call is **$0.541 flat** (up to 30 min, default 5). Polling status / fetching a transcript is **free**. Failed call legs (`ended_by: ERROR`) and 429/502 upstream errors are **not charged**. All settled in USDC on Base or Solana via x402.
 :::
 
 Powered by [Bland.ai](https://bland.ai) (voice AI) + [Twilio](https://twilio.com) (carrier numbers), with x402 settlement at every step.
@@ -21,7 +21,7 @@ An autonomous agent wants to call a restaurant to confirm a reservation, or call
 
 BlockRun collapses all of it to two endpoints and one wallet:
 1. `POST /v1/phone/numbers/buy` — $5, get a US number for 30 days (default; other countries via `country` parameter).
-2. `POST /v1/voice/call` — $0.542, place an outbound call with an AI voice + Bland conversational task.
+2. `POST /v1/voice/call` — $0.541, place an outbound call with an AI voice + Bland conversational task.
 
 Wallet ownership is recorded in Firestore — only the wallet that bought a number can use it to place calls, and only that wallet can renew it.
 
@@ -31,10 +31,10 @@ Wallet ownership is recorded in Firestore — only the wallet that bought a numb
 
 | Endpoint | Method | Price | Description |
 |----------|--------|-------|-------------|
-| `/api/v1/phone/numbers/buy` | POST | **$5.00** | Provision a new number for the calling wallet (30-day lease). US default; other countries via `country` parameter (may require Twilio compliance setup — see below). |
-| `/api/v1/phone/numbers/renew` | POST | **$5.00** | Extend an active number's lease by 30 days |
+| `/api/v1/phone/numbers/buy` | POST | **$5.001** | Provision a new number for the calling wallet (30-day lease). US default; other countries via `country` parameter (may require Twilio compliance setup — see below). |
+| `/api/v1/phone/numbers/renew` | POST | **$5.001** | Extend an active number's lease by 30 days |
 | `/api/v1/phone/numbers/list` | POST | $0.003 | List the calling wallet's active numbers |
-| `/api/v1/voice/call` | POST | **$0.542** | Place an outbound AI call (max 30 min, default 5 min) |
+| `/api/v1/voice/call` | POST | **$0.541** | Place an outbound AI call (max 30 min, default 5 min) |
 | `/api/v1/voice/call/{id}` | GET | **Free** | Poll call status / fetch transcript |
 
 ---
@@ -297,11 +297,11 @@ Use blockrun_wallet to confirm I own a phone number, then use the BlockRun voice
 
 ## Use Cases
 
-### 1. Reservation confirmer ($0.542 per restaurant)
+### 1. Reservation confirmer ($0.541 per restaurant)
 
 Agent calls a restaurant to confirm a booking. Hangs up after confirmation.
 
-### 2. Vendor price-check bot ($0.542 per vendor)
+### 2. Vendor price-check bot ($0.541 per vendor)
 
 Procurement agent calls suppliers, reads off a SKU, asks for current price + lead time, logs the answer.
 
@@ -309,7 +309,7 @@ Procurement agent calls suppliers, reads off a SKU, asks for current price + lea
 
 The wallet-owned numbers can also receive inbound calls — feature is in development. Track `awesome-blockrun/ROADMAP.md`.
 
-### 4. Wellness check bot ($0.542)
+### 4. Wellness check bot ($0.541)
 
 Agent calls a family member on a schedule, has a short conversation, summarizes the call into a Slack message.
 
@@ -319,16 +319,16 @@ Agent calls a family member on a schedule, has a short conversation, summarizes 
 
 | Action | Price | Notes |
 |--------|-------|-------|
-| Buy a number | $5.00 | 30-day lease, US or CA |
-| Renew | $5.00 | +30 days |
-| Place a call | $0.542 | Up to 30 min, default 5 min |
+| Buy a number | $5.001 | 30-day lease, US or CA |
+| Renew | $5.001 | +30 days |
+| Place a call | $0.541 | Up to 30 min, default 5 min |
 | Poll status / fetch transcript | Free | `GET /v1/voice/call/{id}` |
 
 All settled in USDC on Base (or Solana) via x402.
 
 ### Why flat-rate for calls?
 
-Competitors (StablePhone et al) charge $0.54 *per minute* — a 30-min call becomes $16+. BlockRun charges $0.542 *per call* regardless of length (up to the 30-min cap). The math:
+Competitors (StablePhone et al) charge $0.54 *per minute* — a 30-min call becomes $16+. BlockRun charges $0.541 *per call* regardless of length (up to the 30-min cap). The math:
 - Short calls (<1 min, e.g. "is it open?"): we lose pennies, you win big.
 - Long calls (15+ min): we eat the upstream Bland cost, but the call cost is bounded for you.
 

--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -145,7 +145,7 @@ input and output — call `GET /api/v1/models` for the current live list.
 | Grok Imagine | $0.02 |
 | Grok Imagine Pro | $0.07 |
 
-Other media: video from **$0.05/sec**, music **$0.15/track**, text-to-speech **$0.05–$0.10 per 1k characters**, sound effects **$0.052/generation**.
+Other media: video from **$0.05/sec**, music **$0.15/track**, text-to-speech **$0.05–$0.10 per 1k characters**, sound effects **$0.0535/generation**.
 
 ## Cost Comparison: BlockRun vs Direct
 

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -24,19 +24,24 @@ Projects, integrations, and partners building with BlockRun and x402.
 | **Image Generation** | `/v1/images/generations` | $0.015–0.10/image | ✅ Live |
 | **Image Editing** | `/v1/images/image2image` | Per request | ✅ Live |
 | **Video Generation** | `/v1/videos/generations` | Per M tokens | ✅ Live |
-| **Music Generation** | `/v1/audio/generations` | $0.15/track | ✅ Live |
+| **Music Generation** | `/v1/audio/generations` | $0.151/track | ✅ Live |
 | **Text-to-Speech** | `/v1/audio/speech` | $0.05–0.10/1k chars | ✅ Live |
-| **Sound Effects** | `/v1/audio/sound-effects` | $0.052/generation | ✅ Live |
-| **Voice Calls** | `/v1/voice/call` | $0.542 flat | ✅ Live |
-| **Phone Numbers** | `/v1/phone/numbers/*` | $5/30 days | ✅ Live |
-| **Surf Crypto Data** | `/api/v1/surf/*` (83 endpoints) | $0.0095 | ✅ Live |
-| **Search** | `/v1/search` | $0.025/source | ✅ Live |
-| **Exa Web Search** | `/api/v1/exa/*` | $0.002–0.012 | ✅ Live |
+| **Sound Effects** | `/v1/audio/sound-effects` | $0.0535/generation | ✅ Live |
+| **Voice Calls** | `/v1/voice/call` | $0.541 flat | ✅ Live |
+| **Phone Numbers** | `/v1/phone/numbers/*` | $5.001/30 days | ✅ Live |
+| **Surf Crypto Data** | `/api/v1/surf/*` (83 endpoints) | $0.0085 | ✅ Live |
+| **Search** | `/v1/search` | $0.026/source | ✅ Live |
+| **Exa Web Search** | `/api/v1/exa/*` | $0.003–0.011 | ✅ Live |
 | **0x Swap (DEX)** | `/api/v1/zerox/*` | Free | ✅ Live |
-| **Multi-chain RPC** | `/api/v1/rpc/{network}` (40 chains) | $0.004/call | ✅ Live |
-| **Prediction Markets** | `/v1/pm/*` | $0.0095 | ✅ Live |
-| **Trading Markets** | `/api/v1/markets/*` | $0.003 | ✅ Live |
-| **Modal Sandbox** | `/v1/modal/*` | $0.003–0.012 | ✅ Live |
+| **Multi-chain RPC** | `/api/v1/rpc/{network}` (40 chains) | $0.003/call | ✅ Live |
+| **Prediction Markets** | `/v1/pm/*` | $0.0085 | ✅ Live |
+| **DefiLlama** | `/api/v1/defillama/*` | $0.002–0.006 | ✅ Live |
+| **Market Data (Pyth)** | `/v1/{crypto,fx,commodity}/*` | Free | ✅ Live |
+| **Equity Prices (Pyth)** | `/v1/{usstock,stocks}/*` | $0.0010 | ✅ Live |
+| **RealFace Enrollment** | `/v1/realface/enroll` | $0.011 | ✅ Live |
+| **Virtual Portrait** | `/v1/portrait/enroll` | $0.011 | ✅ Live |
+| **Polymarket Funding** | `/v1/polymarket/fund` | $0.011 fee | ✅ Live |
+| **Modal Sandbox** | `/v1/modal/*` | $0.002–0.011 | ✅ Live |
 | **Models** | `/v1/models` | Free | ✅ Live |
 | **Pricing** | `/v1/pricing` | Free | ✅ Live |
 | **Balance** | `/v1/balance` | Free | ✅ Live |

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -293,7 +293,7 @@ tts = SpeechClient()
 res = tts.generate("Hello from BlockRun!", model="elevenlabs/flash-v2.5", voice="sarah", response_format="mp3", speed=1.0)
 print(res.data[0].url)
 
-# Sound effects (flat $0.052/generation)
+# Sound effects (flat $0.0535/generation)
 sfx = tts.sound_effect("rain on a tin roof", duration_seconds=6.0)
 
 voices = tts.list_voices()  # free, 60 req/min/IP
@@ -342,7 +342,7 @@ ranking = surf.call("market/ranking", params={"limit": 20})   # auto GET/POST fr
 catalog = surf.endpoints()                                     # static: every path + tier + price
 ```
 
-Tiers: T1 `$0.0095` (reads/lists), T2 `$0.0095` (AI rankings/trends/search), T3 `$0.0095` (heavy LLM + on-chain SQL). Use `surf.get(path, params)` / `surf.post(path, body)` for explicit verbs.
+Tiers: T1 `$0.0085` (reads/lists), T2 `$0.0085` (AI rankings/trends/search), T3 `$0.0085` (heavy LLM + on-chain SQL). Use `surf.get(path, params)` / `surf.post(path, body)` for explicit verbs.
 
 #### `RpcClient` — multi-chain JSON-RPC
 
@@ -350,10 +350,10 @@ Tiers: T1 `$0.0095` (reads/lists), T2 `$0.0095` (AI rankings/trends/search), T3 
 from blockrun_llm import RpcClient
 
 rpc = RpcClient()
-res = rpc.call("ethereum", "eth_blockNumber")          # $0.004/call
+res = rpc.call("ethereum", "eth_blockNumber")          # $0.003/call
 print(int(res.result, 16), "cache_hit:", res.cache_hit)
 
-# JSON-RPC 2.0 batch — billed $0.004 × N
+# JSON-RPC 2.0 batch — billed $0.003 x N
 batch = rpc.batch("polygon", [{"method": "eth_blockNumber"}, {"method": "eth_gasPrice"}])
 ```
 
@@ -367,8 +367,8 @@ Networks accept names or aliases: `ethereum`/`eth`, `base`, `arbitrum`/`arb`, `o
 from blockrun_llm import PhoneClient
 
 phone = PhoneClient()
-info  = phone.lookup("+14155552671")          # $0.012 — carrier + line type
-fraud = phone.lookup_fraud("+14155552671")    # $0.052 — + SIM-swap / call-forwarding signals
+info  = phone.lookup("+14155552671")          # $0.011 - carrier + line type
+fraud = phone.lookup_fraud("+14155552671")    # $0.051 - + SIM-swap / call-forwarding signals
 num   = phone.buy_number(country="US", area_code="415")  # $5 / 30 days (settles after Twilio confirms)
 phone.renew_number(num["phone_number"])       # $5 / +30 days
 phone.list_numbers()                          # $0.003
@@ -392,19 +392,19 @@ print(call["call_id"])
 status = voice.get_status(call["call_id"])   # free; transcript + recording_url once completed
 ```
 
-`$0.542`/call. `from_` is auto-picked if your wallet owns exactly one provisioned number (see `PhoneClient.buy_number`).
+`$0.541`/call. `from_` is auto-picked if your wallet owns exactly one provisioned number (see `PhoneClient.buy_number`).
 
 #### `PortraitClient` & `RealFaceClient` — `ta_…` identity assets for video
 
 ```python
 from blockrun_llm import PortraitClient, RealFaceClient
 
-# Virtual Portrait — AI character, no KYC, $0.012 one-time
+# Virtual Portrait — AI character, no KYC, $0.011 one-time
 portrait = PortraitClient()
 p = portrait.enroll("My Spokesperson", "https://example.com/character.jpg")
 print(p.asset_id)   # ta_xxxxxxxx → pass to VideoClient(real_face_asset_id=...)
 
-# RealFace — real person, requires on-phone liveness check, $0.012
+# RealFace — real person, requires on-phone liveness check, $0.011
 rf = RealFaceClient()
 init = rf.init("Jane Doe")            # render init.h5_link as a QR for the subject
 rf.wait_for_active(init.group_id)     # blocks until liveness passes (default 180s)
@@ -437,11 +437,18 @@ print(client.onramp())         # Coinbase on-ramp link
 
 ## Prediction Markets (Powered by Predexon)
 
-Access real-time prediction market data from Polymarket, Kalshi, dFlow, Binance, and more via [Predexon](https://predexon.com). No API keys needed — pay-per-request via x402.
+Access real-time prediction market data from Polymarket, Kalshi, Limitless, Opinion, Predict.Fun and Binance via [Predexon](https://predexon.com). No API keys needed — pay-per-request via x402.
+
+> **Retired upstream.** `pm_markets` / `pm_listings` / `pm_outcome` (and
+> `matching-markets`) hit endpoints Predexon sunset on 2026-07-20 — they return
+> `410`. The dFlow endpoints return `404`; that category is gone. Use
+> `markets/search` for cross-venue lookups. `sports/*` is returning an upstream
+> `500` as of 2026-08-04 and is withheld from discovery until it recovers.
+
 
 ### `pm(path, **params)`
 
-Query prediction market GET endpoints. $0.0095 per request.
+Query prediction market GET endpoints. $0.0085 per request.
 
 ```python
 from blockrun_llm import LLMClient
@@ -497,7 +504,7 @@ results = client.pm("markets/search", q="Fed rate")
 Structured query for prediction market POST endpoints. Used for bulk wallet identity lookup and any future POST endpoints.
 
 ```python
-# Bulk wallet identity lookup ($0.0095)
+# Bulk wallet identity lookup ($0.0085)
 batch = client.pm_query("polymarket/wallet/identities", {
     "addresses": ["0xabc...", "0xdef...", "0x123..."],  # up to 200
 })
@@ -517,18 +524,12 @@ batch = client.pm_query("polymarket/wallet/identities", {
 Thin wrappers over `pm()` / `pm_query()` for the most common v2 endpoints. Each forwards keyword arguments as query parameters.
 
 ```python
-# Canonical cross-venue markets (Tier 1)
-markets   = client.pm_markets(venue="polymarket", status="active")
-listings  = client.pm_listings(category="elections")
-outcome   = client.pm_outcome("PXM-12345")
+# Cross-venue search (Tier 2)
+found     = client.pm("markets/search", q="bitcoin 2026")
 
 # Polymarket keyset pagination (Tier 1)
 page      = client.pm_polymarket_markets_keyset(limit="100")
 next_page = client.pm_polymarket_events_keyset(pagination_key=page["pagination"]["next_key"])
-
-# Sports markets (Tier 1)
-categories = client.pm_sports_categories()
-games      = client.pm_sports_markets(league="NBA", status="open")
 
 # Wallet identity & on-chain clustering (Tier 2)
 ident   = client.pm_wallet_identity("0xabc...")
@@ -543,7 +544,6 @@ cluster = client.pm_wallet_cluster("0xabc...")
 | Polymarket | Markets, Events, Trades, Candlesticks (market + token), Orderbooks, Prices, Volume, Open Interest, Activity, Positions, Leaderboards, Cohort Stats, Top Holders, Wallet Analytics, Smart Money, Wallet Identity & Clustering |
 | UMA Oracle | Resolution questions, status, event timeline (Polymarket markets) |
 | Kalshi | Markets, Trades, Orderbooks |
-| dFlow | Trades, Wallet Positions, Wallet P&L |
 | Binance Futures | Candles, Ticks |
 | Limitless | Markets, Orderbooks |
 | Opinion | Markets, Orderbooks |

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -299,18 +299,25 @@ const news   = await search.search('agent payments', { sources: ['web', 'news'],
 const px     = new PriceClient();
 const btc    = await px.price('crypto', 'BTC-USD');
 const rpc    = new RpcClient();
-const block  = await rpc.call('ethereum', 'eth_blockNumber');   // $0.004/call
+const block  = await rpc.call('ethereum', 'eth_blockNumber');   // $0.003/call
 ```
 
 The full method surface mirrors the Python SDK (see the [Python](python.md) page for per-method params, pricing tiers, and `ta_…` identity assets); the only differences are camelCase options and `Promise` returns.
 
 ## Prediction Markets (Powered by Predexon)
 
-Access real-time prediction market data from Polymarket, Kalshi, dFlow, Binance, and more via [Predexon](https://predexon.com). No API keys needed — pay-per-request via x402.
+Access real-time prediction market data from Polymarket, Kalshi, Limitless, Opinion, Predict.Fun and Binance via [Predexon](https://predexon.com). No API keys needed — pay-per-request via x402.
+
+> **Retired upstream.** `pmMarkets` / `pmListings` / `pmOutcome` (and
+> `matching-markets`) hit endpoints Predexon sunset on 2026-07-20 — they return
+> `410`. The dFlow endpoints return `404`; that category is gone. Use
+> `markets/search` for cross-venue lookups. `sports/*` is returning an upstream
+> `500` as of 2026-08-04 and is withheld from discovery until it recovers.
+
 
 ### `pm(path, params?)`
 
-Query prediction market GET endpoints. $0.0095 per request.
+Query prediction market GET endpoints. $0.0085 per request.
 
 ```typescript
 import { LLMClient } from '@blockrun/llm';
@@ -366,7 +373,7 @@ const results = await client.pm("markets/search", { q: "Fed rate" });
 Structured query for prediction market POST endpoints. Used for bulk wallet identity lookup and any future POST endpoints.
 
 ```typescript
-// Bulk wallet identity lookup ($0.0095)
+// Bulk wallet identity lookup ($0.0085)
 const batch = await client.pmQuery("polymarket/wallet/identities", {
   addresses: ["0xabc...", "0xdef...", "0x123..."],  // up to 200
 });
@@ -397,10 +404,6 @@ const nextPage  = await client.pmPolymarketEventsKeyset({
   pagination_key: (page.pagination as Record<string, string>).next_key,
 });
 
-// Sports markets (Tier 1)
-const categories = await client.pmSportsCategories();
-const games      = await client.pmSportsMarkets({ league: "NBA", status: "open" });
-
 // Wallet identity & on-chain clustering (Tier 2)
 const ident   = await client.pmWalletIdentity("0xabc...");
 const batch   = await client.pmWalletIdentities(["0xabc...", "0xdef..."]);  // up to 200
@@ -414,7 +417,6 @@ const cluster = await client.pmWalletCluster("0xabc...");
 | Polymarket | Markets, Events, Trades, Candlesticks (market + token), Orderbooks, Prices, Volume, Open Interest, Activity, Positions, Leaderboards, Cohort Stats, Top Holders, Wallet Analytics, Smart Money, Wallet Identity & Clustering |
 | UMA Oracle | Resolution questions, status, event timeline (Polymarket markets) |
 | Kalshi | Markets, Trades, Orderbooks |
-| dFlow | Trades, Wallet Positions, Wallet P&L |
 | Binance Futures | Candles, Ticks |
 | Limitless | Markets, Orderbooks |
 | Opinion | Markets, Orderbooks |

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -53,13 +53,13 @@ OpenAI-compatible. 71 models across chat, reasoning, coding, and vision — plus
 | GET  | `/api/v1/videos/generations/{id}` | Async video poll (settlement happens here on completion) | Free |
 | POST | `/api/v1/videos` | Standard multimodal `content[]` body — delegates to `/videos/generations` | Per second / token-metered |
 | POST | `/api/v1/audio/speech` | Text-to-speech (ElevenLabs voices) | $0.05–$0.10 / 1k chars |
-| POST | `/api/v1/audio/generations` | Music generation (MiniMax Music) | $0.15 / track |
-| POST | `/api/v1/audio/sound-effects` | Sound-effect generation | $0.052 / generation |
+| POST | `/api/v1/audio/generations` | Music generation (MiniMax Music) | $0.151 / track |
+| POST | `/api/v1/audio/sound-effects` | Sound-effect generation | $0.0535 / generation |
 | GET  | `/api/v1/audio/voices` | List available TTS voices | Free |
-| POST | `/api/v1/portrait/enroll` | Enroll AI character as a Virtual Portrait (`ta_xxx`) for Seedance | **$0.012 / enrollment** |
+| POST | `/api/v1/portrait/enroll` | Enroll AI character as a Virtual Portrait (`ta_xxx`) for Seedance | **$0.011 / enrollment** |
 | GET  | `/api/v1/wallet/{address}/portraits` | List a wallet's enrolled Virtual Portraits | Free (rate-limited) |
 | POST | `/api/v1/realface/init` | Create a RealFace enrollment session, returns h5Link for phone liveness check | Free (rate-limited) |
-| POST | `/api/v1/realface/enroll` | Finalize RealFace enrollment after H5 completes (uploads face + biometric match) | **$0.012 / enrollment** |
+| POST | `/api/v1/realface/enroll` | Finalize RealFace enrollment after H5 completes (uploads face + biometric match) | **$0.011 / enrollment** |
 | GET  | `/api/v1/realface/status` | Poll the state of a RealFace enrollment group | Free (rate-limited) |
 | GET  | `/api/v1/wallet/{address}/realfaces` | List a wallet's enrolled RealFaces | Free (rate-limited) |
 
@@ -69,19 +69,24 @@ Per-model pricing is published at `/api/v1/models` and embedded in every 402 res
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| POST | `/api/v1/search` | Live search (web / news / X) | `max_results × $0.025` / source (default 10) |
-| POST | `/api/v1/exa/search` | Web search | $0.012 / call |
-| POST | `/api/v1/exa/find-similar` | Find semantically similar pages | $0.012 / call |
-| POST | `/api/v1/exa/answer` | AI answer with citations | $0.012 / call |
+| POST | `/api/v1/search` | Live search (web / news / X) | `max_results × $0.026` / source (default 10) |
+| POST | `/api/v1/exa/search` | Web search | $0.011 / call |
+| POST | `/api/v1/exa/find-similar` | Find semantically similar pages | $0.011 / call |
+| POST | `/api/v1/exa/answer` | AI answer with citations | $0.011 / call |
 | POST | `/api/v1/exa/contents` | Extract content from URLs | $0.002 / URL |
 
 ## Voice & Phone
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| POST | `/api/v1/voice/call` | Place an outbound AI voice call | Per call, returned in 402 |
+| POST | `/api/v1/voice/call` | Place an outbound AI voice call | $0.541 / call |
 | GET  | `/api/v1/voice/call/{callId}` | Poll call status / transcript | Free |
-| GET/POST | `/api/v1/phone/{path}` | Phone-number provisioning, lookups, and management | Per endpoint, returned in 402 |
+| POST | `/api/v1/phone/lookup` | Carrier + line-type lookup | $0.011 |
+| POST | `/api/v1/phone/lookup/fraud` | Fraud scoring for a number | $0.051 |
+| POST | `/api/v1/phone/numbers/buy` | Rent a number | $5.001 |
+| POST | `/api/v1/phone/numbers/renew` | Renew a rented number | $5.001 |
+| POST | `/api/v1/phone/numbers/list` | List your rented numbers | $0.002 |
+| POST | `/api/v1/phone/numbers/release` | Release a rented number | Free |
 
 ## Sandbox Compute
 
@@ -89,22 +94,22 @@ Ephemeral, isolated Python sandboxes for agent code execution.
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| POST | `/api/v1/modal/sandbox/create` | Create sandbox | $0.012 (flat for short-lived; per-hour for long-lived) |
-| POST | `/api/v1/modal/sandbox/exec` | Execute a command in a sandbox | $0.003 |
-| POST | `/api/v1/modal/sandbox/status` | Check sandbox status | $0.003 |
-| POST | `/api/v1/modal/sandbox/terminate` | Terminate a sandbox | $0.003 |
+| POST | `/api/v1/modal/sandbox/create` | Create sandbox | $0.011 floor (short-lived); per-hour for long-lived |
+| POST | `/api/v1/modal/sandbox/exec` | Execute a command in a sandbox | $0.002 |
+| POST | `/api/v1/modal/sandbox/status` | Check sandbox status | $0.002 |
+| POST | `/api/v1/modal/sandbox/terminate` | Terminate a sandbox | $0.002 |
 
 ## Prediction Markets (Predexon)
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| GET/POST | `/api/v1/pm/{path}` | Predexon API passthrough — markets, events, odds, history | GET $0.0095 (tier 1) / POST $0.0095 (tier 2) |
+| GET/POST | `/api/v1/pm/{path}` | Predexon passthrough — Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance, UMA oracle, wallet identity | $0.0085, every tier and method |
 
 ## Crypto Data (Surf)
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| GET/POST | `/api/v1/surf/{path}` | Crypto market / on-chain intelligence — exchanges, on-chain analytics, wallet labels, social mindshare, news, search | Tier 1 $0.0095 (reads) · Tier 2 $0.0095 (AI rankings/trends) · Tier 3 $0.0095 (heavy LLM/SQL reports) |
+| GET/POST | `/api/v1/surf/{path}` | Crypto market / on-chain intelligence — exchanges, on-chain analytics, wallet labels, social mindshare, news, search | Tier 1 $0.0085 (reads) · Tier 2 $0.0085 (AI rankings/trends) · Tier 3 $0.0085 (heavy LLM/SQL reports) |
 
 ## 0x Swap (DEX)
 
@@ -112,18 +117,30 @@ Ephemeral, isolated Python sandboxes for agent code execution.
 |---|---|---|---|
 | GET/POST | `/api/v1/zerox/{path}` | 0x Swap + Gasless aggregation passthrough (price / quote / gasless) | **Free passthrough — no x402 payment** |
 
+## DeFi Data (DefiLlama)
+
+| Method | Path | Purpose | Pricing |
+|---|---|---|---|
+| GET | `/api/v1/defillama/protocols` | Every DeFi protocol DefiLlama tracks, with TVL | $0.006 |
+| GET | `/api/v1/defillama/protocol/{slug}` | TVL + breakdown for one protocol (`aave`, `uniswap`, …) | $0.006 |
+| GET | `/api/v1/defillama/chains` | TVL by chain | $0.006 |
+| GET | `/api/v1/defillama/yields` | Every tracked yield pool (lending, LP, staking, vaults) with APY/TVL | $0.006 |
+| GET | `/api/v1/defillama/prices/{coins}` | Token prices, comma-separated coin ids (`coingecko:bitcoin`, `ethereum:0x…`) | $0.002 |
+
+See [DefiLlama](../api-reference/defillama.md).
+
 ## Financial Data (Pyth-backed)
 
-Real-time and historical prices. All `list` endpoints are free. **Crypto, FX, and commodity** price/history are also free; **stock** price/history (US and non-US) are **$0.003/call**.
+Real-time and historical prices. All `list` endpoints are free. **Crypto, FX, and commodity** price/history are also free; **stock** price/history (US and non-US) are **$0.0010/call**.
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
 | GET | `/api/v1/usstock/list` | US tickers | Free |
-| GET | `/api/v1/usstock/price/{symbol}` | US stock spot price | $0.003 |
-| GET | `/api/v1/usstock/history/{symbol}` | US stock OHLC | $0.003 |
+| GET | `/api/v1/usstock/price/{symbol}` | US stock spot price | $0.0010 |
+| GET | `/api/v1/usstock/history/{symbol}` | US stock OHLC | $0.0010 |
 | GET | `/api/v1/stocks/{market}/list` | Non-US markets (HK, JP, ...) | Free |
-| GET | `/api/v1/stocks/{market}/price/{symbol}` | Non-US stock price | $0.003 |
-| GET | `/api/v1/stocks/{market}/history/{symbol}` | Non-US OHLC | $0.003 |
+| GET | `/api/v1/stocks/{market}/price/{symbol}` | Non-US stock price | $0.0010 |
+| GET | `/api/v1/stocks/{market}/history/{symbol}` | Non-US OHLC | $0.0010 |
 | GET | `/api/v1/crypto/list` | Crypto tickers | Free |
 | GET | `/api/v1/crypto/price/{symbol}` | Crypto spot | Free |
 | GET | `/api/v1/crypto/history/{symbol}` | Crypto OHLC | Free |
@@ -140,8 +157,8 @@ Standard JSON-RPC 2.0 to 40 chains through one endpoint — no API key. EVM (`et
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| POST | `/api/v1/rpc/{network}` | Multi-chain JSON-RPC — `ethereum`, `base`, `solana`, `polygon`, `bsc`, `arbitrum`, `bitcoin`, `xrp`, `sui`… (40+, aliases supported) | **$0.004 / call** (batch priced per element) |
-| POST | `/api/v1/solana/rpc` | Solana JSON-RPC (also reachable via `/api/v1/rpc/solana`) | Per-method, returned in 402 |
+| POST | `/api/v1/rpc/{network}` | Multi-chain JSON-RPC — `ethereum`, `base`, `solana`, `polygon`, `bsc`, `arbitrum`, `bitcoin`, `xrp`, `sui`… (40+, aliases supported) | **$0.003 / call** (batch priced per element) |
+| POST | `/api/v1/solana/rpc` | Solana JSON-RPC (also reachable via `/api/v1/rpc/solana`) | $0.0015 / call, batch priced per element |
 
 ## Free Endpoints
 


### PR DESCRIPTION
Follows an audit of BlockRun's published endpoint surface (blockrun#chore/endpoint-surface-sync).

## Removed — upstream probing showed these are gone

Probed `api.predexon.com` directly, 3 runs each, 2026-08-04:

- `/v1/pm/markets`, `/v1/pm/markets/listings`, `/v1/pm/outcomes/{predexon_id}` — all return
  `410 "This endpoint has been sunset as of 2026-07-20. Market matching is discontinued."`
  The #32 note named these as the replacement for `matching-markets`; they were already dead
  when it was written. `markets/search` is the survivor (422 on a missing `?q=`, i.e. alive),
  and every example now uses it.
- `/v1/pm/dflow/*` — bare `{"detail":"Not Found"}`, upstream's no-such-route body. The dFlow
  category is gone from Predexon v2.
- `/api/v1/markets/*` in the ecosystem table — never existed as a route at all.

`/v1/pm/sports/*` is marked temporarily unavailable rather than deleted: it returns a
consistent upstream `500`, which is a partner bug, not a sunset.

## Prices

Every per-call figure in these docs was the customer price under the **old $0.002 transaction
fee**. It returned to $0.001 on 2026-07-29 and the docs never moved, so all of them over-quoted:

| | published | real |
|---|---|---|
| Predexon / Surf (117 occurrences) | 0.0095 | **0.0085** |
| Exa flat · contents | 0.012 · 0.002/URL | **0.011 · 0.003/URL** |
| Modal create · ops | 0.012 · 0.003 | **0.011 · 0.002** |
| RPC · Solana RPC | 0.004 · 0.0025 | **0.003 · 0.0015** |
| Sound effects · Music | 0.052 · 0.15 | **0.0535 · 0.151** |
| Voice call · phone number | 0.542 · 5.00 | **0.541 · 5.001** |
| RealFace / Portrait / Polymarket-fund | 0.012 | **0.011** |
| Equities (Pyth) | 0.003 | **0.0010** |

The last one is not fee drift: `pyth-handler.ts` bills `PYTH_PRICE_USD` flat and deliberately
does not add the transaction fee, so the docs were 3x high.

## New pages

Both for services that were live with no documentation anywhere:

- `api-reference/defillama.md` — 5 endpoints (TVL, per-chain TVL, yields, token prices)
- `api-reference/market-data.md` — the Pyth verticals, including which are free

`x402/endpoints.md` gains a DeFi Data section and per-endpoint phone pricing in place of
"returned in 402"; `ecosystem.md` gains the seven services it omitted.