### PR TITLE
chore(brand): refresh the snapshot — this repo is the mirror, and it was stale

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -59,7 +59,7 @@ BlockRun works with the x402 facilitator network:
 
 | Tool | Description | Install |
 |------|-------------|---------|
-| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP Server — <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools across <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> AI models, image/video/music/speech gen, voice calls, crypto data (Surf), prediction markets, DEX prices, raw JSON-RPC (<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains), DeFi TVL/yields, sandboxed code exec, search | `claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest` |
+| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP Server — <!-- br:mcp.tools -->20<!-- /br:mcp.tools --> tools across <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> AI models, image/video/music/speech gen, voice calls, crypto data (Surf), prediction markets, DEX prices, raw JSON-RPC (<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains), DeFi TVL/yields, sandboxed code exec, search | `claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest` |
 | [nano-banana-blockrun](https://github.com/BlockRunAI/nano-banana-blockrun) | Image generation skill via x402 micropayments | Claude Code skill |
 
 ### Framework Integrations

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Telegram](https://img.shields.io/badge/Telegram-Join-26A5E4)](https://t.me/+mroQv4-4hGgzOGUx)
 [![Research](https://img.shields.io/badge/Research-State%20of%20x402-orange)](./research/State_of_x402_2025.pdf)
 
-> **BlockRun** is the routing & payment layer for AI — one endpoint where AI agents autonomously discover, route, and pay for APIs using USDC via the x402 protocol. BlockRun provides pay-per-request access to <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> large language models (including GPT-5, Claude, Gemini, Grok, DeepSeek, and Kimi), image generation, neural web search (Exa), DEX data, trading signals, and prediction market data. No API keys, no subscriptions, no vendor lock-in.
+> **BlockRun** is the routing & payment layer for AI — one endpoint where AI agents autonomously discover, route, and pay for APIs using USDC via the x402 protocol. BlockRun provides pay-per-request access to <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> large language models (including GPT-5, Claude, Gemini, Grok, DeepSeek, and Kimi), image generation, neural web search (Exa), DEX data, trading signals, and prediction market data. No API keys, no subscriptions, no vendor lock-in.
 >
-> **For Claude Code users:** Add BlockRun in one command — access <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, DEX data, trading signals, and more without managing any API keys.
+> **For Claude Code users:** Add BlockRun in one command — access <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, DEX data, trading signals, and more without managing any API keys.
 > ```bash
 > claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 > ```
@@ -79,7 +79,7 @@ BlockRun is a unified API gateway — pay per request with USDC, no API keys nee
 
 | Product | Endpoint | Pricing | Description |
 |---------|----------|---------|-------------|
-| **LLM Chat** | `/v1/chat/completions` | Per token | OpenAI-compatible, <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, streaming, tool calling |
+| **LLM Chat** | `/v1/chat/completions` | Per token | OpenAI-compatible, <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, streaming, tool calling |
 | **Anthropic-Compat** | `/v1/messages` | Per token | Drop-in for Claude's Messages API |
 | **Image Generation** | `/v1/images/generations` | $0.015–0.10/image | DALL-E 3, GPT Image 1/2, Nano Banana / Pro, Grok Imagine / Pro, CogView-4 |
 | **Image Editing** | `/v1/images/image2image` | Per request | AI-powered inpainting and image-to-image |
@@ -112,7 +112,7 @@ Real-time prediction market data powered by Predexon:
 
 ## Supported Models
 
-**<!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models** across 12+ providers. All accessible through a single OpenAI-compatible API.
+**<!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models** across 12+ providers. All accessible through a single OpenAI-compatible API.
 
 ### LLMs
 
@@ -156,7 +156,7 @@ BlockRun runs on two networks with separate gateways:
 
 | Network | Gateway | Asset | Status |
 |---------|---------|-------|--------|
-| **Base** | `blockrun.ai` | USDC | ✅ Live (<!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models) |
+| **Base** | `blockrun.ai` | USDC | ✅ Live (<!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models) |
 | **Solana** | `sol.blockrun.ai` | USDC | ✅ Live |
 | **Base Sepolia** | `testnet.blockrun.ai` | USDC (testnet) | ✅ Testnet |
 | **Solana Devnet** | `devnet-sol.blockrun.ai` | USDC (devnet) | ✅ Testnet |
@@ -193,7 +193,7 @@ pip install blockrun-llm[solana]
 
 ### blockrun-mcp — Zero API Key Access for Claude Code Users
 
-**[blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp)** is the primary entry point for Claude Code developers. One command gives Claude access to <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, real-time market data, image/video/music generation, AI voice calls, crypto data, and more — with no API keys and no accounts.
+**[blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp)** is the primary entry point for Claude Code developers. One command gives Claude access to <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, real-time market data, image/video/music generation, AI voice calls, crypto data, and more — with no API keys and no accounts.
 
 ```bash
 claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
@@ -205,7 +205,7 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 
 | Tool | What it does |
 |------|-------------|
-| `blockrun_chat` | <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> AI models (GPT-5.5, Claude, Gemini, Grok, DeepSeek, Kimi, and more) |
+| `blockrun_chat` | <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> AI models (GPT-5.5, Claude, Gemini, Grok, DeepSeek, Kimi, and more) |
 | `blockrun_image` | Image generation — gpt-image-2, Nano Banana Pro, Grok Imagine, CogView-4 |
 | `blockrun_video` | Video generation — Sora 2, Seedance 2.0, Grok Imagine Video |
 | `blockrun_realface` | Enroll a real person (liveness) or AI character (Virtual Portrait) for Seedance video |
@@ -353,7 +353,7 @@ The **x402 protocol** (HTTP 402 "Payment Required") lets any HTTP request includ
 
 | Phase | Timeline | Focus |
 |-------|----------|-------|
-| LLM Gateway | Now | Pay-per-request access to <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> AI models |
+| LLM Gateway | Now | Pay-per-request access to <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> AI models |
 | Premium Data | Now | Neural web search (Exa), prediction markets, DEX data, image generation |
 | Agent Wallets | Q2 2026 | Per-agent budgets, spending enforcement, cost attribution |
 | Multi-Chain | Now | Base + Solana gateways live |
@@ -395,7 +395,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 ## Frequently Asked Questions
 
 ### What is BlockRun?
-BlockRun is the routing & payment layer for AI — one endpoint where AI agents discover, route, and pay for APIs using USDC via the x402 protocol. It provides access to <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> LLMs, image generation, neural web search (Exa), and prediction market data without requiring API keys or subscriptions.
+BlockRun is the routing & payment layer for AI — one endpoint where AI agents discover, route, and pay for APIs using USDC via the x402 protocol. It provides access to <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> LLMs, image generation, neural web search (Exa), and prediction market data without requiring API keys or subscriptions.
 
 ### How do AI agents pay for APIs?
 AI agents pay using the x402 protocol — an HTTP-native payment standard. When an agent makes a request, BlockRun returns HTTP 402 with the price. The agent signs a USDC payment locally (private key never leaves the machine), retries with the payment header, and receives the response. Settlement is non-custodial and instant on Base or Solana.

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -2,17 +2,17 @@
   "$schema": "https://blockrun.ai/brand/numbers.schema.json",
   "version": 1,
   "models": {
-    "chatVisible": 66,
-    "totalVisible": 86,
-    "free": 8,
-    "freeWithheld": 17,
-    "image": 8,
+    "chatVisible": 71,
+    "totalVisible": 92,
+    "free": 6,
+    "freeWithheld": 19,
+    "image": 9,
     "video": 5,
     "music": 1,
     "speech": 5,
     "soundfx": 1,
-    "withFallback": 44,
-    "withFallbackAllEntries": 75
+    "withFallback": 46,
+    "withFallbackAllEntries": 79
   },
   "clawrouter": {
     "dimensions": 15,


### PR DESCRIPTION
`brand-numbers.json` here said **66 chat / 86 total / 8 free**; the published artifact says **71 / 92 / 6**. That fed 11 wrong numbers into README.md and ECOSYSTEM.md, live on GitHub.

The marker system worked correctly — it rendered the input it had. **Nothing refreshes that input.** `sync-brand-numbers.mjs` reads the local snapshot and only re-fetches under `--refresh`; `--check` is offline by design so PR CI stays deterministic. The script header defers freshness to a fan-out job that was never built, so all 15 consumers validate markers against their own stale copies and report green.

Measured across the org: **14 of 15 consumers stale**, most at 66/86/8, ClawRouter at 65/85/7. Only ClawRouter-Hermes was current.

**This repo goes first because it is the MIRROR** the others fall back to. Refreshing any other repo first would let a fallback re-seed it from these same stale numbers.

The fan-out job itself, plus a guard that reaches past `docs/`, follow in BlockRunAI/blockrun.