### PR TITLE
docs: README and ECOSYSTEM kept selling dFlow, DALL-E 3 and the retired $0.0095

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -7,7 +7,7 @@ BlockRun is a unified API gateway — pay per request with USDC, no API keys nee
 | Product | Endpoint | Pricing | Status |
 |---------|----------|---------|--------|
 | **LLM Chat** | `/v1/chat/completions` | Per token | ✅ Live |
-| **Image Generation** | `/v1/images/generations` | $0.02–0.15/image | ✅ Live |
+| **Image Generation** | `/v1/images/generations` | $0.015–0.15/image | ✅ Live |
 | **Image Editing** | `/v1/images/image2image` | Per request | ✅ Live |
 | **Search** | `/v1/search` | $0.025/source | ✅ Live |
 | **Prediction Markets** | `/v1/pm/*` | $0.0085 | ✅ Live |
@@ -92,7 +92,7 @@ Want to add an integration? [Open an issue](https://github.com/blockrunai/awesom
 | `free` | Free models only | NVIDIA GPT-OSS 120B/20B |
 | `eco` | Cheapest capable | DeepSeek, Gemini Flash Lite |
 | `auto` | Balanced cost/quality | GPT-5 Mini, Gemini Flash |
-| `premium` | Best quality | Claude Opus 4.6, GPT-5.5 |
+| `premium` | Best quality | Claude Opus 5, GPT-5.6 Sol |
 
 ## AI Providers
 
@@ -100,7 +100,7 @@ BlockRun routes to these AI providers via x402:
 
 | Provider | Models | Input/Output per 1M tokens |
 |----------|--------|---------------------------|
-| OpenAI | GPT-5.5, GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-5.4 Mini, GPT-5 Mini, GPT-5.4 Nano, o1, o1-mini, o3, o3-mini | $0.05–$30.00 / $0.40–$180.00 |
+| OpenAI | GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-5.4 Mini, GPT-5 Mini, GPT-5.4 Nano, o1, o3, o3-mini, o4-mini | $0.10–$30.00 / $0.40–$180.00 |
 | Anthropic | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $1.00–$10.00 / $5.00–$50.00 |
 | Google | Gemini 3.1 Pro, Gemini 3 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 3.1 Flash Lite, Gemini 2.5 Flash Lite | $0.10–$2.00 / $0.40–$12.00 |
 | DeepSeek | DeepSeek Chat (V3.2), DeepSeek Reasoner | $0.28 / $0.42 |
@@ -115,8 +115,14 @@ BlockRun routes to these AI providers via x402:
 | Model | Price per image |
 |-------|----------------|
 | OpenAI GPT Image 1 | $0.02–0.04 |
+| OpenAI ChatGPT Images 2.0 | $0.06–0.12 |
 | Nano Banana | $0.05 |
+| Nano Banana 2 | $0.09 |
 | Nano Banana Pro | $0.10–0.15 |
+| Grok Imagine | $0.02 |
+| Grok Imagine Pro | $0.07 |
+| Seedream 5.0 Pro | $0.045–0.09 |
+| CogView-4 | $0.015–0.02 |
 
 ---
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -10,7 +10,7 @@ BlockRun is a unified API gateway — pay per request with USDC, no API keys nee
 | **Image Generation** | `/v1/images/generations` | $0.02–0.15/image | ✅ Live |
 | **Image Editing** | `/v1/images/image2image` | Per request | ✅ Live |
 | **Search** | `/v1/search` | $0.025/source | ✅ Live |
-| **Prediction Markets** | `/v1/pm/*` | $0.0095 | ✅ Live |
+| **Prediction Markets** | `/v1/pm/*` | $0.0085 | ✅ Live |
 | **Models** | `/v1/models` | Free | ✅ Live |
 | **Pricing** | `/v1/pricing` | Free | ✅ Live |
 | **Balance** | `/v1/balance` | Free | ✅ Live |
@@ -45,7 +45,7 @@ BlockRun works with the x402 facilitator network:
 | [Coinbase CDP](https://coinbase.com/cloud) | x402 facilitator infrastructure |
 | [x402 Foundation](https://x402.org) | Protocol development |
 | [thirdweb](https://thirdweb.com) | Wallet & payment infrastructure |
-| [Predexon](https://predexon.com) | Prediction market data (Polymarket, Kalshi, dFlow, Binance) |
+| [Predexon](https://predexon.com) | Prediction market data (Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance) |
 | [Modal](https://modal.com) | Sandbox compute (managed Python sandboxes for isolated code execution) |
 
 ## Community Integrations
@@ -115,7 +115,6 @@ BlockRun routes to these AI providers via x402:
 | Model | Price per image |
 |-------|----------------|
 | OpenAI GPT Image 1 | $0.02–0.04 |
-| OpenAI DALL-E 3 | $0.04–0.08 |
 | Nano Banana | $0.05 |
 | Nano Banana Pro | $0.10–0.15 |
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ img = ImageClient(private_key="0x...")
 result = img.generate("A cyberpunk city at sunset", model="openai/gpt-image-1")
 
 # Neural web search via Exa
-results = client.search("latest AI agent frameworks")  # $0.012/search on Base or Solana
+results = client.search("latest AI agent frameworks")  # $0.011/search on Base or Solana
 ```
 
 ```typescript
@@ -81,18 +81,18 @@ BlockRun is a unified API gateway — pay per request with USDC, no API keys nee
 |---------|----------|---------|-------------|
 | **LLM Chat** | `/v1/chat/completions` | Per token | OpenAI-compatible, <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, streaming, tool calling |
 | **Anthropic-Compat** | `/v1/messages` | Per token | Drop-in for Claude's Messages API |
-| **Image Generation** | `/v1/images/generations` | $0.015–0.10/image | DALL-E 3, GPT Image 1/2, Nano Banana / Pro, Grok Imagine / Pro, CogView-4 |
+| **Image Generation** | `/v1/images/generations` | $0.015–0.10/image | GPT Image 1/2, Nano Banana / 2 / Pro, Grok Imagine / Pro, Seedream 5.0 Pro, CogView-4 |
 | **Image Editing** | `/v1/images/image2image` | Per request | AI-powered inpainting and image-to-image |
 | **Video Generation** | `/v1/videos/generations` | Per M tokens | Seedance 1.5 Pro, 2.0 Fast, 2.0 Pro (with BytePlus RealFace support); Grok Imagine Video |
 | **Music Generation** | `/v1/audio/generations` | Per track | Suno-powered text-to-music |
-| **Voice Calls** | `/v1/voice/call` | $0.542/call (flat, ≤30min) | Outbound AI conversation calls — Bland.ai upstream |
-| **Phone Numbers** | `/v1/phone/numbers/*` | $5/30 days | Wallet-owned US/CA numbers — Twilio upstream |
-| **Surf Crypto Data** | `/api/v1/surf/*` | $0.0095 | 83 endpoints: CEX, on-chain SQL, prediction markets, wallet labels, social mindshare, news, search (asksurf.ai) |
-| **Web Search** | `/api/v1/exa/*` | $0.012/search | Neural web search, find-similar, page contents, AI answers (Exa) |
+| **Voice Calls** | `/v1/voice/call` | $0.541/call (flat, ≤30min) | Outbound AI conversation calls — Bland.ai upstream |
+| **Phone Numbers** | `/v1/phone/numbers/*` | $5.001/30 days | Wallet-owned US/CA numbers — Twilio upstream |
+| **Surf Crypto Data** | `/api/v1/surf/*` | $0.0085 | 83 endpoints: CEX, on-chain SQL, prediction markets, wallet labels, social mindshare, news, search (asksurf.ai) |
+| **Web Search** | `/api/v1/exa/*` | $0.011/search | Neural web search, find-similar, page contents, AI answers (Exa) |
 | **DEX Aggregation** | `/api/v1/zerox/*` | Free | 0x Swap V2 + Gasless V2 across 100+ venues |
 | **Sandbox Runtime** | `/api/v1/modal/*` | Per run | Secure isolated Python execution (Modal) |
-| **Prediction Markets** | `/v1/pm/*` | $0.0095 | Polymarket, Kalshi, dFlow, Binance Futures (Predexon) |
-| **Trading Markets** | `/api/v1/markets/*` | $0.003 | Equity tickers across US, KR, JP, CN, etc. |
+| **Prediction Markets** | `/v1/pm/*` | $0.0085 | Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance Futures (Predexon) |
+| **Trading Markets** | `/api/v1/markets/*` | $0.002 | Equity tickers across US, KR, JP, CN, etc. |
 | **Models** | `/v1/models` | Free | List all available models with pricing |
 | **Pricing** | `/v1/pricing` | Free | Detailed pricing for all models |
 | **Balance** | `/v1/balance` | Free | Check USDC wallet balance |
@@ -103,10 +103,20 @@ Real-time prediction market data powered by Predexon:
 
 | Market | Endpoints | Price |
 |--------|-----------|-------|
-| **Polymarket** | Markets, events, trades, orderbooks, leaderboards, positions | $0.0095 |
-| **Kalshi** | Markets, trades, orderbooks | $0.0095 |
-| **dFlow** | Trades, positions, P&L | $0.0095 |
-| **Binance Futures** | Candles, ticks | $0.0095 |
+| **Polymarket** | Markets, events, trades, orderbooks, leaderboards, positions, crypto | $0.0085 |
+| **Kalshi** | Markets, trades, orderbooks | $0.0085 |
+| **Limitless** | Markets, orderbooks | $0.0085 |
+| **Opinion** | Markets, orderbooks | $0.0085 |
+| **Predict.Fun** | Markets, orderbooks | $0.0085 |
+| **Binance Futures** | Candles, ticks | $0.0085 |
+| **UMA oracle** | Proposed and settled markets | $0.0085 |
+| **Wallet intelligence** | Identity resolution, on-chain cluster | $0.0085 |
+| **Cross-venue** | `markets/search` across every venue above | $0.0085 |
+
+> **dFlow was removed 2026-08-04.** All three `dflow/*` paths return upstream
+> route-not-found; the category no longer exists in Predexon v2. `sports/*` is
+> temporarily withheld — it returns an upstream `500` and is excluded from
+> discovery until the partner restores it.
 
 ---
 
@@ -142,7 +152,6 @@ Real-time prediction market data powered by Predexon:
 | Model | Price per image |
 |-------|----------------|
 | OpenAI GPT Image 1 | $0.02–0.04 |
-| OpenAI DALL-E 3 | $0.04–0.08 |
 | Nano Banana | $0.05 |
 | Nano Banana Pro | $0.10–0.15 |
 
@@ -295,7 +304,7 @@ Built into both Python and TypeScript SDKs. Also available as standalone: [ClawR
 | Partner | Product | Description |
 |---------|---------|-------------|
 | [Exa](https://exa.ai) | Web Search | Neural web search, find-similar, page contents, AI-grounded answers |
-| [Predexon](https://predexon.com) | Prediction Markets | Polymarket, Kalshi, dFlow, Binance Futures data |
+| [Predexon](https://predexon.com) | Prediction Markets | Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance Futures data |
 | [Modal](https://modal.com) | Sandbox Compute | Managed Python sandboxes for isolated code execution |
 
 ### x402 Facilitators

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ BlockRun is a unified API gateway — pay per request with USDC, no API keys nee
 |---------|----------|---------|-------------|
 | **LLM Chat** | `/v1/chat/completions` | Per token | OpenAI-compatible, <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, streaming, tool calling |
 | **Anthropic-Compat** | `/v1/messages` | Per token | Drop-in for Claude's Messages API |
-| **Image Generation** | `/v1/images/generations` | $0.015–0.10/image | GPT Image 1/2, Nano Banana / 2 / Pro, Grok Imagine / Pro, Seedream 5.0 Pro, CogView-4 |
+| **Image Generation** | `/v1/images/generations` | $0.015–0.15/image | GPT Image 1/2, Nano Banana / 2 / Pro, Grok Imagine / Pro, Seedream 5.0 Pro, CogView-4 |
 | **Image Editing** | `/v1/images/image2image` | Per request | AI-powered inpainting and image-to-image |
-| **Video Generation** | `/v1/videos/generations` | Per M tokens | Seedance 1.5 Pro, 2.0 Fast, 2.0 Pro (with BytePlus RealFace support); Grok Imagine Video |
+| **Video Generation** | `/v1/videos/generations` | Per M tokens | Seedance 1.5 Pro, 2.0 Fast, 2.0 Pro, 2.5 (with BytePlus RealFace support); Grok Imagine Video |
 | **Music Generation** | `/v1/audio/generations` | Per track | Suno-powered text-to-music |
 | **Voice Calls** | `/v1/voice/call` | $0.541/call (flat, ≤30min) | Outbound AI conversation calls — Bland.ai upstream |
 | **Phone Numbers** | `/v1/phone/numbers/*` | $5.001/30 days | Wallet-owned US/CA numbers — Twilio upstream |
@@ -92,7 +92,7 @@ BlockRun is a unified API gateway — pay per request with USDC, no API keys nee
 | **DEX Aggregation** | `/api/v1/zerox/*` | Free | 0x Swap V2 + Gasless V2 across 100+ venues |
 | **Sandbox Runtime** | `/api/v1/modal/*` | Per run | Secure isolated Python execution (Modal) |
 | **Prediction Markets** | `/v1/pm/*` | $0.0085 | Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance Futures (Predexon) |
-| **Trading Markets** | `/api/v1/markets/*` | $0.002 | Equity tickers across US, KR, JP, CN, etc. |
+| **Trading Markets** | `/v1/stocks/{market}/*` | $0.002 | Equity tickers across US, KR, JP, CN, etc. (Pyth) |
 | **Models** | `/v1/models` | Free | List all available models with pricing |
 | **Pricing** | `/v1/pricing` | Free | Detailed pricing for all models |
 | **Balance** | `/v1/balance` | Free | Check USDC wallet balance |
@@ -111,7 +111,7 @@ Real-time prediction market data powered by Predexon:
 | **Binance Futures** | Candles, ticks | $0.0085 |
 | **UMA oracle** | Proposed and settled markets | $0.0085 |
 | **Wallet intelligence** | Identity resolution, on-chain cluster | $0.0085 |
-| **Cross-venue** | `markets/search` across every venue above | $0.0085 |
+| **Cross-venue** | `markets/search` — Polymarket, Kalshi, Limitless, Opinion, Predict.Fun in one call | $0.0085 |
 
 > **dFlow was removed 2026-08-04.** All three `dflow/*` paths return upstream
 > route-not-found; the category no longer exists in Predexon v2. `sports/*` is
@@ -128,7 +128,7 @@ Real-time prediction market data powered by Predexon:
 
 | Provider | Models | Input/Output per 1M tokens |
 |----------|--------|---------------------------|
-| **OpenAI** | GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-5.4 Mini, GPT-5 Mini, GPT-5.4 Nano, o1, o1-mini, o3, o3-mini | $0.05–$30.00 / $0.40–$180.00 |
+| **OpenAI** | GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-5.4 Mini, GPT-5 Mini, GPT-5.4 Nano, o1, o3, o3-mini, o4-mini | $0.10–$30.00 / $0.40–$180.00 |
 | **Anthropic** | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $1.00–$10.00 / $5.00–$50.00 |
 | **Google** | Gemini 3.1 Pro, Gemini 3 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 3.1 Flash Lite, Gemini 2.5 Flash Lite | $0.10–$2.00 / $0.40–$12.00 |
 | **DeepSeek** | DeepSeek Chat (V3.2), DeepSeek Reasoner (V3.2 thinking) | $0.28 / $0.42 |
@@ -144,7 +144,7 @@ Real-time prediction market data powered by Predexon:
 |-------|---------------------------|
 | OpenAI o1 | $15.00 / $60.00 |
 | OpenAI o3 | $2.00 / $8.00 |
-| OpenAI o1-mini, o3-mini | $1.10 / $4.40 |
+| OpenAI o3-mini, o4-mini | $1.10 / $4.40 |
 | DeepSeek Reasoner | $0.28 / $0.42 |
 
 ### Image Generation
@@ -152,8 +152,14 @@ Real-time prediction market data powered by Predexon:
 | Model | Price per image |
 |-------|----------------|
 | OpenAI GPT Image 1 | $0.02–0.04 |
+| OpenAI ChatGPT Images 2.0 | $0.06–0.12 |
 | Nano Banana | $0.05 |
+| Nano Banana 2 | $0.09 |
 | Nano Banana Pro | $0.10–0.15 |
+| Grok Imagine | $0.02 |
+| Grok Imagine Pro | $0.07 |
+| Seedream 5.0 Pro | $0.045–0.09 |
+| CogView-4 | $0.015–0.02 |
 
 > Full pricing: `GET /v1/pricing` or see [Pricing docs](./docs/products/intelligence/pricing.md)
 
@@ -224,7 +230,7 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 | `blockrun_exa` | Neural semantic search + grounded answers |
 | `blockrun_markets` | Polymarket, Kalshi, sports markets |
 | `blockrun_polymarket` | Place real USDC-settled Polymarket orders (CLOB V2 on Polygon) — discover markets with `blockrun_markets` first |
-| `blockrun_surf` | 84 crypto data endpoints (CEX, on-chain SQL, social, wallet labels) |
+| `blockrun_surf` | 83 crypto data endpoints (CEX, on-chain SQL, social, wallet labels) |
 | `blockrun_price` | Pyth quotes: crypto, FX, commodities, stocks |
 | `blockrun_dex` | Live DEX prices and liquidity via DexScreener (free) |
 | `blockrun_rpc` | Raw JSON-RPC on <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains — Ethereum, Base, Solana, Bitcoin, Sui, NEAR (Tatum gateway) |
@@ -256,7 +262,7 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 | `free` | Free models only | NVIDIA GPT-OSS 120B/20B |
 | `eco` | Cheapest capable | DeepSeek, Gemini Flash Lite |
 | `auto` | Balanced cost/quality | GPT-5 Mini, Gemini Flash |
-| `premium` | Best quality | Claude Opus 4.6, GPT-5.4 |
+| `premium` | Best quality | Claude Opus 5, GPT-5.6 Sol |
 
 Built into both Python and TypeScript SDKs. Also available as standalone: [ClawRouter](https://github.com/BlockRunAI/ClawRouter)
 
@@ -419,7 +425,7 @@ BlockRun is agent-native — it uses wallet signatures for authentication instea
 The x402 protocol is an HTTP-native payment standard based on HTTP status code 402 ("Payment Required"). It allows any HTTP request to include a cryptographic USDC payment, enabling machine-to-machine payments without accounts, credit cards, or KYC verification. BlockRun is a leading implementation of x402.
 
 ### How much does BlockRun cost?
-BlockRun uses pay-per-request pricing with no minimums or subscriptions. Prices start at $0.003 per request for the cheapest models. Provider cost plus a 5% margin. $5 in USDC is enough for thousands of requests.
+BlockRun uses pay-per-request pricing with no minimums or subscriptions. Prices start at $0.002 per request for the cheapest endpoints. Provider cost plus a 5% margin. $5 in USDC is enough for thousands of requests.
 
 ---
 

--- a/docs/api-reference/surf.md
+++ b/docs/api-reference/surf.md
@@ -29,7 +29,7 @@ Surf unifies all of it behind one schema, billed per-call in stablecoins. An age
 
 | Category | Endpoints | What it covers |
 |----------|-----------|----------------|
-| **prediction** | 17 | Polymarket + Kalshi + dFlow markets, trades, positions, odds |
+| **prediction** | 17 | Polymarket + Kalshi markets, trades, positions, odds |
 | **social** | 11 | Mindshare, sentiment, KOL coverage, trending tokens on social |
 | **search** | 11 | Project / token / wallet / news search |
 | **market** | 11 | Token rankings, Fear & Greed, ETF flows, options, liquidations, on-chain indicators (NUPL/SOPR/MVRV), technical indicators (RSI/MACD/Bollinger/EMA) |


### PR DESCRIPTION
#33 corrected ~140 stale prices across `docs/`. The repo's own front page was not in that
sweep, so `README.md` and `ECOSYSTEM.md` — the first thing anyone reads — kept advertising
three things that no longer exist.

## Products that are gone

| Claim | Reality |
|---|---|
| **dFlow** row in the Predexon table (+ 2 more mentions) | All three `dflow/*` paths return upstream route-not-found. Category removed from Predexon v2, de-registered in BlockRunAI/blockrun#336. |
| **DALL-E 3**, in three places, with prices | Not in `models.ts` at all. |
| `docs/api-reference/surf.md`: "prediction — Polymarket + Kalshi + **dFlow**" | Surf has zero dflow endpoints. All 17 are Polymarket or Kalshi. |

## Prices frozen at the old transaction fee

Every one was the customer price under the **$0.002** fee that returned to $0.001 on
2026-07-29:

```
Predexon / Surf   $0.0095 -> $0.0085   (6 places)
voice/call        $0.542  -> $0.541
exa               $0.012  -> $0.011
equities          $0.003  -> $0.002
phone numbers     $5      -> $5.001    UNDER — the 402 signs $5.001
```

## The Predexon table predated five venues

It listed four. The live registry publishes nine categories: **Limitless, Opinion,
Predict.Fun, the UMA oracle and wallet intelligence** were all missing, and
`markets/search` is the one surviving cross-venue endpoint after the 2026-07-20 matching
sunset. Rebuilt from `PUBLISHABLE_PREDEXON_ENDPOINTS`, with a dated note recording that
dFlow is gone and `sports/*` is **withheld** (upstream `500`, a partner bug) rather than
deleted — so the note stays accurate whichever way that resolves.

Every number here was read off the registries in `blockrun/src/lib/`, not copied from
another doc.