### PR TITLE
docs: align every published rate with the catalog and the new zero chat margin

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -103,8 +103,8 @@ BlockRun routes to these AI providers via x402:
 | OpenAI | GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-5.4 Mini, GPT-5 Mini, GPT-5.4 Nano, o1, o3, o3-mini, o4-mini | $0.10–$30.00 / $0.40–$180.00 |
 | Anthropic | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $1.00–$10.00 / $5.00–$50.00 |
 | Google | Gemini 3.1 Pro, Gemini 3 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 3.1 Flash Lite, Gemini 2.5 Flash Lite | $0.10–$2.00 / $0.40–$12.00 |
-| DeepSeek | DeepSeek Chat (V3.2), DeepSeek Reasoner | $0.28 / $0.42 |
-| Z.AI | GLM-5, GLM-5 Turbo | $1.00–$1.20 / $3.20–$5.00 |
+| DeepSeek | DeepSeek V4 Flash Chat, DeepSeek V4 Flash Reasoner, DeepSeek V4 Pro | $0.14–$0.435 / $0.28–$0.87 |
+| Z.AI | GLM-5.2, GLM-5.1, GLM-5, GLM-5 Turbo | $1.00–$1.40 / $3.20–$4.40 |
 | Moonshot | Kimi K3 (1M context, 2.8T open MoE, flagship), Kimi K2.7, Kimi K2.5 | $0.60–$3.00 / $3.00–$15.00 |
 | MiniMax | MiniMax M2.7 (204K context, reasoning) | $0.30 / $1.20 |
 | Qwen | Qwen3.7 Max (1M context, Alibaba flagship) | $1.48 / $4.43 |

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Real-time prediction market data powered by Predexon:
 | **OpenAI** | GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-5.4 Mini, GPT-5 Mini, GPT-5.4 Nano, o1, o3, o3-mini, o4-mini | $0.10–$30.00 / $0.40–$180.00 |
 | **Anthropic** | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $1.00–$10.00 / $5.00–$50.00 |
 | **Google** | Gemini 3.1 Pro, Gemini 3 Pro Preview, Gemini 3 Flash Preview, Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 3.1 Flash Lite, Gemini 2.5 Flash Lite | $0.10–$2.00 / $0.40–$12.00 |
-| **DeepSeek** | DeepSeek Chat (V3.2), DeepSeek Reasoner (V3.2 thinking) | $0.28 / $0.42 |
-| **Z.AI** | GLM-5.2, GLM-5.1, GLM-5, GLM-5 Turbo | $0.60–$1.40 / $1.92–$4.40 |
+| **DeepSeek** | DeepSeek V4 Flash Chat, DeepSeek V4 Flash Reasoner, DeepSeek V4 Pro | $0.14–$0.435 / $0.28–$0.87 |
+| **Z.AI** | GLM-5.2, GLM-5.1, GLM-5, GLM-5 Turbo | $1.00–$1.40 / $3.20–$4.40 |
 | **Moonshot** | Kimi K3 (1M context, 2.8T open MoE, flagship), Kimi K2.7, Kimi K2.5 | $0.60–$3.00 / $3.00–$15.00 |
 | **MiniMax** | MiniMax M2.7 (204K context, reasoning) | $0.30 / $1.20 |
 | **Qwen** | Qwen3.7 Max (1M context, Alibaba flagship) | $1.48 / $4.43 |
@@ -145,7 +145,7 @@ Real-time prediction market data powered by Predexon:
 | OpenAI o1 | $15.00 / $60.00 |
 | OpenAI o3 | $2.00 / $8.00 |
 | OpenAI o3-mini, o4-mini | $1.10 / $4.40 |
-| DeepSeek Reasoner | $0.28 / $0.42 |
+| DeepSeek V4 Flash Reasoner | $0.14 / $0.28 |
 
 ### Image Generation
 

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -59,7 +59,7 @@ Each model object in the response includes:
 **59 chat / LLM models** are publicly listed on mainnet, plus **8 image**, **5 video**, **1 music**, **5 text-to-speech**, and **1 sound-effects** model — covering chat, image, video, music, speech, and sound-effects generation from one API. Additional deprecated / superseded LLM IDs remain routable for backwards compatibility but are hidden from the catalog. Call `GET /api/v1/models` for the exact live list.
 :::
 
-All prices shown are provider rates. BlockRun adds a **5% platform fee** to cover infrastructure costs.
+All prices shown are provider rates — and, for per-token chat, also the billed rates: BlockRun adds **no platform margin** on chat tokens (we match OpenRouter), only the flat $0.001/request transaction fee. Media and Live Search still carry a 5% platform fee.
 
 ### OpenAI GPT-5.6 Family
 
@@ -151,9 +151,9 @@ Grok bills a **long-context tier** at 2x the rates above once a request's prompt
 
 | Model ID | Name | Input Price | Output Price | Context |
 |----------|------|-------------|--------------|---------|
-| `deepseek/deepseek-chat` | DeepSeek V4 Flash Chat | $0.20/M | $0.40/M | 1M |
+| `deepseek/deepseek-chat` | DeepSeek V4 Flash Chat | $0.14/M | $0.28/M | 1M |
 | `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro | $0.435/M | $0.87/M | 1M |
-| `deepseek/deepseek-reasoner` | DeepSeek Reasoner | $0.28/M | $0.42/M | 128K |
+| `deepseek/deepseek-reasoner` | DeepSeek Reasoner | $0.14/M | $0.28/M | 128K |
 
 ### Z.AI
 
@@ -161,7 +161,7 @@ Grok bills a **long-context tier** at 2x the rates above once a request's prompt
 |----------|------|-------------|--------------|---------|
 | `zai/glm-5.2` | GLM-5.2 (flagship) | $1.40/M | $4.40/M | 1M |
 | `zai/glm-5.1` | GLM-5.1 | $1.40/M | $4.40/M | 200K |
-| `zai/glm-5` | GLM-5 | $0.60/M | $1.92/M | 200K |
+| `zai/glm-5` | GLM-5 | $1.00/M | $3.20/M | 200K |
 | `zai/glm-5-turbo` | GLM-5 Turbo | $1.20/M | $4.00/M | 200K |
 
 ### Moonshot
@@ -254,7 +254,7 @@ Prices are per 1 million tokens. Your actual cost depends on:
 
 The SDK calculates the exact price before each request.
 
-**Want to save 87% automatically?** [ClawRouter](../products/routing/clawrouter.md) routes each request to the cheapest model that can handle it.
+**Want to save 88% automatically?** [ClawRouter](../products/routing/clawrouter.md) routes each request to the cheapest model that can handle it.
 
 ## Example
 
@@ -301,7 +301,7 @@ Call any model ID from this catalog through the OpenAI-compatible endpoint.
 Generate images with the GPT Image, Nano Banana, and CogView model family.
 :::
 
-:::card{title="Save 87% with ClawRouter" href="../products/routing/clawrouter.md" icon="Route"}
+:::card{title="Save 88% with ClawRouter" href="../products/routing/clawrouter.md" icon="Route"}
 Route each prompt to the cheapest model that can handle it, automatically.
 :::
 

--- a/docs/getting-started/agent-developers.md
+++ b/docs/getting-started/agent-developers.md
@@ -133,7 +133,7 @@ def smart_route(task: str, importance: str) -> str:
     elif importance == "medium":
         model = "anthropic/claude-haiku-4.5"  # $1.00/M
     else:
-        model = "deepseek/deepseek-chat"  # $0.28/M
+        model = "deepseek/deepseek-chat"  # $0.14/M
 
     return client.chat(model, task)
 ```
@@ -178,7 +178,7 @@ results = asyncio.run(process_batch(my_items))
 
 ### Cost-Optimized
 - `google/gemini-2.5-flash-lite` — Best value ($0.10/$0.40 per 1M)
-- `deepseek/deepseek-chat` — Great value ($0.28/$0.42 per 1M)
+- `deepseek/deepseek-chat` — Great value ($0.14/$0.28 per 1M)
 - `nvidia/gpt-oss-120b` — Free (NVIDIA-hosted)
 
 ### Quality-Optimized

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -21,7 +21,7 @@ No API keys. No monthly bills. Just usage-based payments in USDC.
 
 ## Available Models
 
-Reference provider rates per 1M tokens (BlockRun adds a 5% margin at billing — see [Pricing](pricing.md) for exact list prices).
+Provider rates per 1M tokens. Since 2026-08-07 these are also the BILLED rates — per-token chat carries no platform margin (we match OpenRouter); only the flat $0.001/request transaction fee is added. See [Pricing](pricing.md).
 
 ### OpenAI
 | Model | Input | Output |
@@ -41,7 +41,7 @@ Reference provider rates per 1M tokens (BlockRun adds a 5% margin at billing —
 | Claude Opus 4.5 | $5.00/M | $25.00/M |
 | Claude Sonnet 5 | $3.00/M | $15.00/M |
 | Claude Sonnet 4.6 | $3.00/M | $15.00/M |
-| Claude Haiku 4.5 | $0.80/M | $4.00/M |
+| Claude Haiku 4.5 | $1.00/M | $5.00/M |
 
 ### Google
 | Model | Input | Output |
@@ -54,7 +54,7 @@ Reference provider rates per 1M tokens (BlockRun adds a 5% margin at billing —
 |-------|-------|--------|
 | GLM-5.2 (flagship, 1M context) | $1.40/M | $4.40/M |
 | GLM-5.1 | $1.40/M | $4.40/M |
-| GLM-5 | $0.60/M | $1.92/M |
+| GLM-5 | $1.00/M | $3.20/M |
 | GLM-5 Turbo | $1.20/M | $4.00/M |
 
 ### Moonshot
@@ -76,7 +76,7 @@ Reference provider rates per 1M tokens (BlockRun adds a 5% margin at billing —
 ### DeepSeek
 | Model | Input | Output |
 |-------|-------|--------|
-| DeepSeek V4 Flash Chat | $0.20/M | $0.40/M |
+| DeepSeek V4 Flash Chat | $0.14/M | $0.28/M |
 | DeepSeek V4 Pro | $0.435/M | $0.87/M |
 
 ### Free tier
@@ -101,7 +101,7 @@ The 5% covers:
 **No subscriptions. No minimums. No prepaid credits.**
 
 :::tip{title="Cut costs automatically"}
-Don't want to pick models by hand? [ClawRouter](../routing/clawrouter.md) routes each request to the cheapest model that can handle it — 87% lower cost than pinning one flagship for every request.
+Don't want to pick models by hand? [ClawRouter](../routing/clawrouter.md) routes each request to the cheapest model that can handle it — 88% lower cost than pinning one flagship for every request.
 :::
 
 ## Quick Start
@@ -163,7 +163,7 @@ Process these 500 files using DeepSeek
 
 DeepSeek costs a fraction of the flagship models for similar quality on many routine tasks.
 
-**Want automatic cost optimization?** Try [ClawRouter](../routing/clawrouter.md) — it saves 87% by routing each request to the cheapest model that can handle it.
+**Want automatic cost optimization?** Try [ClawRouter](../routing/clawrouter.md) — it saves 88% by routing each request to the cheapest model that can handle it.
 
 ### Second Opinion
 

--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -1,19 +1,20 @@
 ---
 title: Intelligence Pricing
-description: BlockRun Intelligence pricing — provider cost plus 5%, a full per-token price list, image rates, and a free tier of 8 models.
+description: BlockRun Intelligence pricing — per-token chat at provider cost with no platform margin, a full price list, image rates, and a free tier of 8 models.
 ---
 
 # Intelligence Pricing
 
-Pay only for what you use. Provider cost + 5%.
+Pay only for what you use. Per-token chat is billed at **provider cost** — no platform margin.
 
 ## Pricing Formula
 
 ```
-Your cost = Provider cost + 5%
+Your cost = Provider cost          (per-token chat — no margin, matches OpenRouter)
+              + $0.001 / request     (flat x402 transaction fee)
 ```
 
-The 5% margin covers:
+Media generation and Live Search still carry a 5% platform margin, which covers:
 - x402 settlement infrastructure
 - Smart routing and reliability
 - No API key management
@@ -39,39 +40,39 @@ The free tier costs $0 — 10 reasoning, coding, and vision models with no per-t
 
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
-| GPT-5.6 Sol (flagship) | $5.25 | $31.50 |
-| GPT-5.6 Sol Pro | $5.25 | $31.50 |
-| GPT-5.6 Terra | $2.10 | $12.60 |
-| GPT-5.6 Terra Pro | $1.05 | $6.30 |
-| GPT-5.6 Luna | $0.21 | $1.26 |
-| GPT-5.6 Luna Pro | $0.11 | $0.63 |
-| GPT-5.5 | $5.25 | $31.50 |
-| GPT-5.5 Pro | $31.50 | $189.00 |
-| GPT-5.4 | $2.63 | $15.75 |
-| GPT-5.4 Pro | $31.50 | $189.00 |
-| GPT-5.2 | $1.84 | $14.70 |
+| GPT-5.6 Sol (flagship) | $5.00 | $30.00 |
+| GPT-5.6 Sol Pro | $5.00 | $30.00 |
+| GPT-5.6 Terra | $2.00 | $12.00 |
+| GPT-5.6 Terra Pro | $1.00 | $6.00 |
+| GPT-5.6 Luna | $0.20 | $1.20 |
+| GPT-5.6 Luna Pro | $0.10 | $0.60 |
+| GPT-5.5 | $5.00 | $30.00 |
+| GPT-5.5 Pro | $30.00 | $180.00 |
+| GPT-5.4 | $2.50 | $15.00 |
+| GPT-5.4 Pro | $30.00 | $180.00 |
+| GPT-5.2 | $1.75 | $14.00 |
 
 ### Anthropic
 
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
-| Claude Fable 5 (most capable) | $10.50 | $52.50 |
-| Claude Opus 5 (flagship) | $5.25 | $26.25 |
-| Claude Opus 4.8 (previous flagship) | $5.25 | $26.25 |
-| Claude Opus 4.7 | $5.25 | $26.25 |
-| Claude Opus 4.5 | $5.25 | $26.25 |
-| Claude Sonnet 5 | $3.15 | $15.75 |
-| Claude Sonnet 4.6 | $3.15 | $15.75 |
-| Claude Haiku 4.5 | $0.84 | $4.20 |
+| Claude Fable 5 (most capable) | $10.00 | $50.00 |
+| Claude Opus 5 (flagship) | $5.00 | $25.00 |
+| Claude Opus 4.8 (previous flagship) | $5.00 | $25.00 |
+| Claude Opus 4.7 | $5.00 | $25.00 |
+| Claude Opus 4.5 | $5.00 | $25.00 |
+| Claude Sonnet 5 | $3.00 | $15.00 |
+| Claude Sonnet 4.6 | $3.00 | $15.00 |
+| Claude Haiku 4.5 | $1.00 | $5.00 |
 
 ### Google
 
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
-| Gemini 3.1 Pro | $2.10 | $12.60 |
-| Gemini 3.6 Flash | $1.58 | $7.88 |
-| Gemini 3.5 Flash | $1.58 | $9.45 |
-| Gemini 3.5 Flash Lite | $0.32 | $2.63 |
+| Gemini 3.1 Pro | $2.00 | $12.00 |
+| Gemini 3.6 Flash | $1.50 | $7.50 |
+| Gemini 3.5 Flash | $1.50 | $9.00 |
+| Gemini 3.5 Flash Lite | $0.30 | $2.50 |
 
 Gemini Pro models double the input rate and add 50% to the output rate above 200K prompt tokens (the whole request reprices), mirroring Google's official long-context pricing — e.g. Gemini 2.5 Pro is $2.63 in · $15.75 out above the threshold. Flash tiers are flat.
 
@@ -79,9 +80,9 @@ Gemini Pro models double the input rate and add 50% to the output rate above 200
 
 | Model | Input (per 1M) | Output (per 1M) | Context |
 |-------|---------------|-----------------|---------|
-| Grok 4.5 (flagship) | $2.63 | $9.45 | 500K |
-| Grok 4.3 | $1.58 | $4.20 | 1M |
-| Grok Build 0.1 | $1.58 | $3.15 | 256K |
+| Grok 4.5 (flagship) | $2.50 | $9.00 | 500K |
+| Grok 4.3 | $1.50 | $4.00 | 1M |
+| Grok Build 0.1 | $1.50 | $3.00 | 256K |
 
 Grok doubles the per-token rates above 200K prompt tokens (the whole request reprices — e.g. Grok 4.5 is $5.25 in · $18.90 out above the threshold), mirroring xAI's official long-context tier. Live Search adds $0.025 per source used.
 
@@ -89,38 +90,38 @@ Grok doubles the per-token rates above 200K prompt tokens (the whole request rep
 
 | Model | Input (per 1M) | Output (per 1M) | Context |
 |-------|---------------|-----------------|---------|
-| GLM-5.2 (flagship) | $1.47 | $4.62 | 1M |
-| GLM-5.1 | $1.47 | $4.62 | 200K |
-| GLM-5 | $0.63 | $2.02 | 200K |
-| GLM-5 Turbo | $1.26 | $4.20 | 200K |
+| GLM-5.2 (flagship) | $1.40 | $4.40 | 1M |
+| GLM-5.1 | $1.40 | $4.40 | 200K |
+| GLM-5 | $1.00 | $3.20 | 200K |
+| GLM-5 Turbo | $1.20 | $4.00 | 200K |
 
 ### Moonshot
 
 | Model | Input (per 1M) | Output (per 1M) | Context |
 |-------|---------------|-----------------|---------|
-| Kimi K3 | $3.15 | $15.75 | 1M |
-| Kimi K2.7 | $1.00 | $4.20 | 256K |
+| Kimi K3 | $3.00 | $15.00 | 1M |
+| Kimi K2.7 | $0.95 | $4.00 | 256K |
 
 ### MiniMax
 
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
-| MiniMax M3 | $0.32 | $1.26 |
+| MiniMax M3 | $0.30 | $1.20 |
 
 ### Qwen
 
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
-| Qwen3.7 Max | $1.55 | $4.65 |
-| Qwen3.7 Plus | $0.34 | $1.34 |
-| Qwen3.7 Flash | $0.03 | $0.14 |
+| Qwen3.7 Max | $1.48 | $4.42 |
+| Qwen3.7 Plus | $0.32 | $1.28 |
+| Qwen3.7 Flash | $0.03 | $0.13 |
 
 ### DeepSeek
 
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
-| DeepSeek V4 Flash Chat | $0.21 | $0.42 |
-| DeepSeek V4 Pro | $0.46 | $0.91 |
+| DeepSeek V4 Flash Chat | $0.14 | $0.28 |
+| DeepSeek V4 Pro | $0.43 | $0.87 |
 
 ### Free Tier (8 models)
 
@@ -154,7 +155,7 @@ Other media: video from **$0.05/sec**, music **$0.15/track**, text-to-speech **$
 | OpenAI GPT-5.4 | $2.50/$15.00 | $2.63/$15.75 | +5% |
 | Anthropic Claude Sonnet 5 | $3.00/$15.00 | $3.15/$15.75 | +5% |
 | Anthropic Claude Sonnet 4.6 | $3.00/$15.00 | $3.15/$15.75 | +5% |
-| DeepSeek V4 Flash Chat | $0.20/$0.40 | $0.21/$0.42 | +5% |
+| DeepSeek V4 Flash Chat | $0.14/$0.28 | $0.14/$0.28 | +0% |
 
 You pay 5% more, but you get:
 - No API key management
@@ -194,7 +195,7 @@ print(f"Requests: {usage['request_count']}")
 
 ### 0. Use ClawRouter for Automatic Savings
 
-**Save 87% on average** with [ClawRouter](../routing/clawrouter.md) — it automatically routes each request to the cheapest model that can handle it.
+**Save 88% on average** with [ClawRouter](../routing/clawrouter.md) — it automatically routes each request to the cheapest model that can handle it.
 
 ```
 /model blockrun/auto
@@ -259,7 +260,7 @@ How the OpenAI-compatible API works and which model fits each task.
 :::
 
 :::card{title="Smart routing" href="../routing/clawrouter.md" icon="Route"}
-Save 87% on average by routing each request to the cheapest capable model.
+Save 88% on average by routing each request to the cheapest capable model.
 :::
 
 :::card{title="Wallet setup" href="../../getting-started/wallet-setup.md" icon="Wallet"}

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -5,7 +5,7 @@ description: ClawRouter is a smart LLM router for OpenClaw that picks the optima
 
 # ClawRouter
 
-**87% cheaper than pinning one flagship for every request — 98% on `eco`. Automatically.**
+**88% cheaper than pinning one flagship for every request — 98% on `eco`. Automatically.**
 
 ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 71 models, zero API keys.
 
@@ -151,7 +151,7 @@ Default `auto` profile primaries (cost-balanced; switch to `free` profile for $0
 | **SIMPLE** | moonshot/kimi-k2.7 | $0.95/M in / $4.00/M out | free-tier model (FREE) | Q&A, summaries, simple tasks |
 | **MEDIUM** | google/gemini-3.5-flash | $1.50/M in / $9.00/M out | free-tier model (FREE) | Analysis, writing, coding |
 | **COMPLEX** | google/gemini-3.1-pro | $2.00/M in / $12.00/M out | free-tier model (FREE) | Advanced reasoning, research |
-| **REASONING** | deepseek/deepseek-reasoner | $0.28/M in / $0.42/M out | free-tier model (FREE) | Math, logic, proofs |
+| **REASONING** | deepseek/deepseek-reasoner | $0.14/M in / $0.28/M out | free-tier model (FREE) | Math, logic, proofs |
 
 *Prices shown per 1M tokens (after 5% BlockRun markup)*
 
@@ -159,10 +159,10 @@ Default `auto` profile primaries (cost-balanced; switch to `free` profile for $0
 
 | Prompt | Routed To | Cost | Savings |
 |--------|-----------|------|---------|
-| "What is 2+2?" | DeepSeek | $0.40/M | 99% |
+| "What is 2+2?" | DeepSeek | $0.28/M | 99% |
 | "Summarize this article" | Gemini 3.5 Flash | $9.00/M | 70% |
 | "Build a React component" | Claude Sonnet 4.6 | $15.00/M | 80% |
-| "Prove this theorem" | DeepSeek Reasoner | $0.42/M | 99% |
+| "Prove this theorem" | DeepSeek Reasoner | $0.28/M | 99% |
 | "Run 50 parallel searches" | Kimi K2.7 | $4.00/M | 87% |
 
 ## Features
@@ -268,7 +268,7 @@ Using Claude Opus 5 for everything:
 Smart routing to appropriate models:
 
 ```
-70 simple requests → DeepSeek ($0.40/M) = $0.03
+70 simple requests → DeepSeek ($0.28/M) = $0.02
 20 medium requests → Claude Haiku ($4.00/M) = $0.08
 10 complex requests → Claude Opus 5 ($25.00/M) = $0.25
 

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -123,11 +123,11 @@ BlockRun routes to these providers via x402:
 | Provider | Models | Input/Output per 1M tokens |
 |----------|--------|---------------------------|
 | OpenAI | GPT-5.5, GPT-5.4, GPT-5.4 Pro, GPT-5.2 | $1.75–$30.00 / $14.00–$180.00 |
-| Anthropic | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $0.80–$10.00 / $4.00–$50.00 |
+| Anthropic | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $1.00–$10.00 / $5.00–$50.00 |
 | Google | Gemini 3.1 Pro, Gemini 3.5 Flash | $1.50–$2.00 / $9.00–$12.00 |
-| DeepSeek | DeepSeek V4 Flash Chat, DeepSeek V4 Pro, DeepSeek Reasoner | $0.20–$0.44 / $0.40–$0.87 |
+| DeepSeek | DeepSeek V4 Flash Chat, DeepSeek V4 Pro, DeepSeek Reasoner | $0.14–$0.435 / $0.28–$0.87 |
 | xAI | Grok 4.5, Grok 4.3, Grok 4 Fast, Grok Code Fast 1 | $0.20–$3.00 / $0.50–$18.00 |
-| Z.AI | GLM-5.2 (1M context), GLM-5.1, GLM-5, GLM-5 Turbo | $0.60–$1.40 / $1.92–$4.40 |
+| Z.AI | GLM-5.2 (1M context), GLM-5.1, GLM-5, GLM-5 Turbo | $1.00–$1.40 / $3.20–$4.40 |
 | Moonshot | Kimi K3 (1M context, image + text input), Kimi K2.7 (256K, image + video) | $0.95–$3.00 / $4.00–$15.00 |
 | MiniMax | MiniMax M3 (1M context) | $0.30 / $1.20 |
 | Qwen | Qwen3.7 Max (1M context, flagship) | $1.48 / $4.43 |

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -117,7 +117,7 @@ print(f"Paying from: {address}")
 
 ## Smart Routing (ClawRouter)
 
-**Save 87% on LLM costs automatically.**
+**Save 88% on LLM costs automatically.**
 
 The `smart_chat()` method uses ClawRouter's 14-dimension scoring algorithm to route each request to the optimal model. Routing decisions run locally in <1ms — your prompts never leave your machine for routing.
 

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -128,7 +128,7 @@ console.log(`Paying from: ${address}`);
 
 ## Smart Routing (ClawRouter)
 
-**Save 87% on LLM costs automatically.**
+**Save 88% on LLM costs automatically.**
 
 The `smartChat()` method uses ClawRouter's 14-dimension scoring algorithm to route each request to the optimal model. Routing decisions run locally in <1ms — your prompts never leave your machine for routing.
 


### PR DESCRIPTION
Companion to the gateway change in BlockRunAI/blockrun. Merge that one's decision first — this repo only republishes what the catalog says.

## Why

Per-token chat now bills at **provider cost, no platform margin** (matching OpenRouter). Every post-markup sheet here was therefore overstating what a caller pays by 5%. Separately, three catalog prices were simply wrong.

## What changed

**`products/intelligence/pricing.md` — 73 cells.** The whole Full Price List was a ×1.05 table. Values were snapped against `models.ts` rather than divided by 1.05, so a wrong input couldn't silently produce a tidy-looking wrong output. Two cells refused to snap, and both turned out to be real doc bugs rather than script failures:

- `Claude Haiku 4.5 $0.84/$4.20` — implies a $0.80/$4.00 cost. Real cost is **$1.00/$5.00**, and `api-reference/models.md` already said so. Two sheets in this repo disagreed and the ×1.05 was derived from the wrong one.
- `GLM-5 $0.63/$2.02` — implies the old $0.60/$1.92.

**Three prices corrected everywhere they appear:**

| Model | Was | Now | Why |
|---|---|---|---|
| GLM-5 | 0.60 / 1.92 | **1.00 / 3.20** | Z.AI raised the rate after the promo retired on 2026-06-06; nothing re-read their page |
| DeepSeek V4 Flash chat + reasoner | 0.20 / 0.40 | **0.14 / 0.28** | v4-pro was updated when DeepSeek cut, the flash SKUs were not |
| Claude Haiku 4.5 | 0.80 / 4.00 | **1.00 / 5.00** | doc-only error |

**Savings claim 87% → 88%** in 9 places — DeepSeek getting cheaper moved `BRAND.savingsAutoPct`. The per-scenario `87%` in the clawrouter routing table is deliberately left as-is; it's one example's saving, not the published headline.

Media and Live Search keep their 5% margin and are untouched. The pricing formula section now states which is which.

## Guard gap found

The docs guard matches `save N%` but not `N% cheaper`, so `clawrouter.md:8` and `overview.md:104` were stale **and** unguarded. Both fixed here; widening the matcher is tracked in the gateway PR.

## Verification

`tsc --noEmit` clean, 1737/1737 tests pass in the gateway repo against this submodule. Both price guards mutation-tested: reintroducing a stale rate goes red, restoring goes green.