### PR TITLE
fix(docs): exa/contents quoted the old $0.002 per-transaction fee

### DIFF
--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -15,7 +15,7 @@ Exa gives agents a live internet connection with structured, grounded results �
 
 **A complete research workflow costs $0.033:**
 - 1 search ($0.011) → find relevant URLs
-- 5 page reads in one call ($0.003/URL → $0.011) → get full content
+- 5 page reads in one call ($0.002/URL + $0.001 per-request fee → $0.011) → get full content
 - 1 synthesized answer ($0.011) → grounded conclusion
 
 ## Endpoints
@@ -24,7 +24,7 @@ Exa gives agents a live internet connection with structured, grounded results �
 |----------|--------|-------|-------------|
 | `/api/v1/exa/search` | POST | $0.011 | Neural web search — find relevant URLs for a query |
 | `/api/v1/exa/answer` | POST | $0.011 | Get a cited, synthesized answer to any question |
-| `/api/v1/exa/contents` | POST | $0.003/URL | Fetch full Markdown text from a list of URLs |
+| `/api/v1/exa/contents` | POST | $0.002/URL + $0.001/request | Fetch full Markdown text from a list of URLs |
 | `/api/v1/exa/find-similar` | POST | $0.011 | Find pages similar to a given URL |
 
 ---
@@ -121,7 +121,9 @@ Best for: "What is X?", "How does Y work?", "What's the current state of Z?"
 
 Fetch the full text content from a list of URLs. Returns clean Markdown — no HTML, no boilerplate — ready to drop into an LLM context window.
 
-**This is the cheapest way to read web pages:** $0.002 per URL. Fetching 10 pages costs $0.022.
+**This is the cheapest way to read web pages:** $0.002 per URL, plus the $0.001
+per-request fee charged once no matter how many URLs you pass. Fetching 10 pages
+costs $0.021; a single page costs $0.003.
 
 ### Request Body
 
@@ -320,7 +322,7 @@ const similar = await client.exaFindSimilar("https://blockrun.ai", { numResults:
 | `/exa/search` | $0.011 |
 | `/exa/answer` | $0.011 |
 | `/exa/find-similar` | $0.011 |
-| `/exa/contents` | $0.002 per URL |
+| `/exa/contents` | $0.002 per URL + $0.001 per request |
 
 Payment is in USDC on Base or Solana via x402. No account needed — your wallet is your identity.
 

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -73,7 +73,7 @@ Per-model pricing is published at `/api/v1/models` and embedded in every 402 res
 | POST | `/api/v1/exa/search` | Web search | $0.011 / call |
 | POST | `/api/v1/exa/find-similar` | Find semantically similar pages | $0.011 / call |
 | POST | `/api/v1/exa/answer` | AI answer with citations | $0.011 / call |
-| POST | `/api/v1/exa/contents` | Extract content from URLs | $0.002 / URL |
+| POST | `/api/v1/exa/contents` | Extract content from URLs | $0.002 / URL + $0.001 / request |
 
 ## Voice & Phone
 


### PR DESCRIPTION
`exa-search.md` shipped `Fetching 10 pages costs $0.022`. That total is 10 x $0.002 plus the **old** $0.002 per-transaction fee — the fee has moved twice since. Live x402 quotes **$0.021**.

Verified against production by decoding `x-payment-required` (the 402 body under-reports; the fee is added inside `buildPaymentRequirements`):

| URLs | doc said | live |
|---|---|---|
| 1 | $0.002 | **$0.003** |
| 5 | $0.011 ✅ | $0.011 |
| 10 | $0.022 | **$0.021** |

Three places also called $0.003 the *per-URL* price. That is the one-URL total, so pricing a 10-URL call from it over-estimates by 50%. One sentence had the unit wrong and the total right at the same time.

Now states unit and fee separately, so the next fee change has one number to update instead of worked totals to re-derive.

A guard lands with the pointer bump in blockrun: any line carrying unit + count + total must satisfy `count x unit + TRANSACTION_FEE_USD`. It found a third stale spot on its first run (the endpoint table at line 27) that three manual passes had missed.