### PR TITLE
fix(docs): three pages said 18 MCP tools, published count is 20

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ Franklin — the AI agent with a wallet. Writes code and spends USDC across 71 m
 :::
 
 :::card{title="I use Claude Code / Cursor" href="getting-started/quickstart.md" icon="Terminal"}
-One MCP install adds 18 `blockrun_*` tools to your assistant. Best for Claude Code, Cursor, and other MCP clients.
+One MCP install adds 20 `blockrun_*` tools to your assistant. Best for Claude Code, Cursor, and other MCP clients.
 :::
 
 :::card{title="I'm building an agent / backend" href="getting-started/sdk-developers.md" icon="Code"}

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -174,7 +174,7 @@ For more help, see [MCP Troubleshooting](../mcp/troubleshooting.md).
 ::::cards
 
 :::card{title="Browse the MCP tools" href="../mcp/blockrun-mcp.md" icon="Boxes"}
-The full list of 18 `blockrun_*` tools — chat, image, video, search, markets, RPC, and more.
+The full list of 20 `blockrun_*` tools — chat, image, video, search, markets, RPC, and more.
 :::
 
 :::card{title="Generate images" href="../products/creation/nano-banana.md" icon="Image"}

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -94,7 +94,7 @@ If a call returns `402 Payment Required` after retrying, your wallet is empty or
 ::::cards
 
 :::card{title="Browse all tools" href="../mcp/blockrun-mcp.md" icon="Boxes"}
-The full list of 18 `blockrun_*` tools — chat, image, video, search, markets, RPC, and more.
+The full list of 20 `blockrun_*` tools — chat, image, video, search, markets, RPC, and more.
 :::
 
 :::card{title="Explore the models" href="../products/intelligence/overview.md" icon="Brain"}


### PR DESCRIPTION
`quickstart.md` contradicted itself in one page: **20** tools in the intro, **18** in a card at the bottom. `README.md` and `claude-code.md` had the same stale 18. Published value is **20**.

The sweep matched none of them: it looks for a number followed by the claim word, and `18 \`blockrun_*\` tools` has an inline-code span in between, so the number read as unattached. Widened by one short token in blockrun — and that widening is what found the two pages I had missed reading by hand.