### PR TITLE
fix(docs): total is 93 — seedance (+1) crossed with deepseek-v4-flash EOL (−1)

### DIFF
--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -1,6 +1,6 @@
 ---
 title: AgentKit Integration
-description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 92 AI models.
+description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 93 AI models.
 ---
 
 # AgentKit Integration

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -1,6 +1,6 @@
 ---
 title: ElizaOS Integration
-description: Add the BlockRun plugin to ElizaOS so your agents reach 92 AI models via x402 micropayments — no per-provider API keys.
+description: Add the BlockRun plugin to ElizaOS so your agents reach 93 AI models via x402 micropayments — no per-provider API keys.
 ---
 
 # ElizaOS Integration
@@ -11,7 +11,7 @@ Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 70 mode
 BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
 :::
 
-[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 92 AI models via x402 micropayments.
+[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 93 AI models via x402 micropayments.
 
 ## Setup
 

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -1,6 +1,6 @@
 ---
 title: GOAT SDK Integration
-description: Combine GOAT SDK's cross-chain execution with BlockRun's 92 AI models, paid per request over x402 — until the official plugin ships.
+description: Combine GOAT SDK's cross-chain execution with BlockRun's 93 AI models, paid per request over x402 — until the official plugin ships.
 ---
 
 # GOAT SDK Integration

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -85,7 +85,7 @@ Use GPT-5 to get a second opinion on this code
 Ask Grok what's trending on X right now
 ```
 
-Claude automatically routes to 92 AI models and pays via x402.
+Claude automatically routes to 93 AI models and pays via x402.
 
 ### Trading (alpha-mcp)
 

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -5,7 +5,7 @@ description: A Model Context Protocol server that gives Claude Code 70 models, c
 
 # BlockRun MCP
 
-Give Claude Code access to 92 AI models, 80+ crypto data endpoints, voice calls, image/video/music generation, prediction markets, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 93 AI models, 80+ crypto data endpoints, voice calls, image/video/music generation, prediction markets, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -12,7 +12,7 @@ Projects, integrations, and partners building with BlockRun and x402.
 | Product | Description | Link |
 |---------|-------------|------|
 | [alpha-mcp](https://github.com/BlockRunAI/alpha-mcp) | AI crypto trading for Claude | [GitHub](https://github.com/BlockRunAI/alpha-mcp) |
-| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP server for 92 AI models, images, video, music, voice, prediction markets, crypto data, sandbox runtime, smart routing | [GitHub](https://github.com/BlockRunAI/blockrun-mcp) |
+| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP server for 93 AI models, images, video, music, voice, prediction markets, crypto data, sandbox runtime, smart routing | [GitHub](https://github.com/BlockRunAI/blockrun-mcp) |
 | [nano-banana](https://github.com/BlockRunAI/nano-banana-blockrun) | Image generation skill | [GitHub](https://github.com/BlockRunAI/nano-banana-blockrun) |
 
 ## API Products

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -1,11 +1,11 @@
 ---
 title: Go SDK
-description: The Go SDK for BlockRun — call 92 AI models, generate images, and manage wallets over x402 micropayments with no API keys.
+description: The Go SDK for BlockRun — call 93 AI models, generate images, and manage wallets over x402 micropayments with no API keys.
 ---
 
 # Go SDK
 
-The Go SDK for BlockRun provides access to 92 AI models via x402 micropayments — pay per call in USDC, no API keys.
+The Go SDK for BlockRun provides access to 93 AI models via x402 micropayments — pay per call in USDC, no API keys.
 
 **Source:** [github.com/BlockRunAI/blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go) · `go get github.com/BlockRunAI/blockrun-llm-go` · MIT
 


### PR DESCRIPTION
Predicted in #43: blockrun PR #366 merged mid-flight, so the totals my sweep set to 92 are now 93. Chat (70) and free (5) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)