### PR TITLE
docs: add Metaculus Forecast Bot to Projects Built with BlockRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Built into both Python and TypeScript SDKs. Also available as standalone: [ClawR
 | [Spraay](https://github.com/plagtech/spraay-x402-gateway) | x402 Gateway | Multi-chain x402 payment gateway with dual-provider AI inference (BlockRun + OpenRouter) |
 | [NoFx](https://github.com/NoFxAiOS/nofx) | Crypto Trading | Personal AI trading assistant - any market, any model, pay with USDC |
 | [Voyage GEO](https://github.com/onvoyage-ai/voyage-geo-agent) | AI Analytics | Generative Engine Optimization - track how AI models reference your brand across ChatGPT, Claude, Gemini & more |
+| [Metaculus Forecast Bot](https://github.com/eltociear/metaculus-forecast-bot) | Prediction Markets | Autonomous forecasting bot for the funded Metaculus AI Benchmark tournaments - BlockRun is its LLM backend, authenticated by wallet signature with no API key |
 
 > Built something with BlockRun? [Add it here!](https://github.com/blockrunai/awesome-blockrun/issues)
 


### PR DESCRIPTION
Adds one row to **Projects Built with BlockRun**, following the invitation under that table.

**[eltociear/metaculus-forecast-bot](https://github.com/eltociear/metaculus-forecast-bot)** — an autonomous forecasting bot competing in the funded [Metaculus AI Benchmark](https://www.metaculus.com/aib/) tournaments (Summer FutureEval $50k, MiniBench $1k rolling, Market Pulse $7.5k, Animal Futures $3.4k).

**How it uses BlockRun**

`nvidia/gpt-oss-120b` through `blockrun-llm` is the bot's LLM backend:

```python
from blockrun_llm import LLMClient
text = LLMClient(private_key=key).chat(BLOCKRUN_MODEL, prompt, ...)
```

The bot is otherwise stdlib-only — `blockrun-llm` is its single third-party dependency.

**Why it's a real dependency, not a badge**

Its previous backend (a HuggingFace free tier) depleted mid-season and every forecast started abstaining, which froze participation in the $50k tournament outright. BlockRun's free NVIDIA tier restored it with **no API key and no quota** — wallet-signature auth alone — and it has been forecasting on it since. The failure and the switch are documented in the code.

For maintainers: the entry sits in the existing **Prediction Markets** category, next to your own Polymarket agent. Diff is one line; no other content touched.
