### PR TITLE
fix(docs): strip br: markers — this tree is rendered, so they show up on the page

### DIFF
--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -59,7 +59,7 @@ Franklin is the autonomous agent on top of the BlockRun stack — it uses the sa
 ::::cards
 
 :::card{title="ClawRouter" href="routing/clawrouter.md" icon="Route"}
-The router Franklin uses — <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions -->-dimension scoring plus portfolio ranking picks the cheapest capable model.
+The router Franklin uses — 15-dimension scoring plus portfolio ranking picks the cheapest capable model.
 :::
 
 :::card{title="BlockRun MCP" href="../mcp/blockrun-mcp.md" icon="Terminal"}

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -71,9 +71,9 @@ No external API calls. No LLM inference in the classification step. Pure keyword
 
 Steps 4 and 7 are the V3 portfolio layer: the tier says how much capability the request needs, the task type says what *kind* of work it is, and the portfolio ranks the eligible models against calibrated per-task evidence. The tier primary is a starting point, not the answer — a code-agent turn and a multiple-choice question in the same tier get different models.
 
-### <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions -->-Dimension Scoring
+### 15-Dimension Scoring
 
-The classifier reads the prompt and scores it across <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions --> weighted dimensions:
+The classifier reads the prompt and scores it across 15 weighted dimensions:
 
 | Dimension | Weight | Detects |
 |---|---|---|
@@ -163,7 +163,7 @@ Default `auto` profile primaries (cost-balanced; switch to `free` profile for $0
 | **COMPLEX** | google/gemini-3.1-pro | Advanced reasoning, research, long documents |
 | **REASONING** | xai/grok-4-1-fast-reasoning | Math, logic, proofs |
 
-The primary is where the tier starts, not where the request necessarily lands: the portfolio ranks every capability-eligible candidate for the detected task, so a tool-calling turn and a proof in the same tier resolve to different models. Switch to the `free` profile for $0 routing across the <!-- br:models.free -->5<!-- /br:models.free --> free models.
+The primary is where the tier starts, not where the request necessarily lands: the portfolio ranks every capability-eligible candidate for the detected task, so a tool-calling turn and a proof in the same tier resolve to different models. Switch to the `free` profile for $0 routing across the 5 free models.
 
 ## Smart Routing Examples
 
@@ -179,7 +179,7 @@ The primary is where the tier starts, not where the request necessarily lands: t
 
 ### 100% Local Routing
 
-- <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions -->-dimension weighted scoring runs on your machine in <1ms
+- 15-dimension weighted scoring runs on your machine in <1ms
 - No external API calls for routing decisions
 - Full privacy - your prompts never leave your machine for routing
 
@@ -195,7 +195,7 @@ Access all major providers through one wallet:
 - **Z.AI**: GLM-5.2 (flagship, 1M context), GLM-5.1, GLM-5, GLM-5 Turbo
 - **Moonshot**: Kimi K3 (flagship, 1M context, image + text), Kimi K2.7 (256K, image + video)
 - **MiniMax**: MiniMax M3
-- **Free tier (all FREE)**: <!-- br:models.free -->5<!-- /br:models.free --> NVIDIA-hosted chat, reasoning and vision models with no per-token charge
+- **Free tier (all FREE)**: 5 NVIDIA-hosted chat, reasoning and vision models with no per-token charge
 
 [View all models →](../intelligence/pricing.md)
 

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -117,13 +117,13 @@ print(f"Paying from: {address}")
 
 ## Smart Routing (Router Core)
 
-**Save <!-- br:savings.autoVsBaselinePct -->88<!-- /br:savings.autoVsBaselinePct -->% on LLM costs automatically.**
+**Save 88% on LLM costs automatically.**
 
 Routing runs on [Router Core](https://github.com/BlockRunAI/router-core) — the same engine the TypeScript SDK and the BlockRun gateway use, so an identical request routes identically everywhere. Decisions are local (<1ms, no extra model call): your prompts never leave your machine to be routed.
 
 Three stages:
 
-1. **Classify** — <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions --> weighted dimensions map the request onto a capability tier, and a task classifier labels the shape of the work (`chat`, `code_edit`, `code_agent`, `tool_agent`, `reasoning_math`, `long_context`, `extraction`, `vision`, …).
+1. **Classify** — 15 weighted dimensions map the request onto a capability tier, and a task classifier labels the shape of the work (`chat`, `code_edit`, `code_agent`, `tool_agent`, `reasoning_math`, `long_context`, `extraction`, `vision`, …).
 2. **Filter** — capability constraints are hard filters. A model that cannot hold the conversation, emit the requested `max_tokens`, call tools, or read images is dropped *before* scoring, so the router never picks a model the request would fail on.
 3. **Rank** — survivors are scored on task affinity, cost, speed and reliability. The winner serves the request; the rest become the fallback chain, walked automatically on a timeout, a saturated upstream (429) or a 5xx.
 
@@ -186,7 +186,7 @@ response = client.chat_completion("blockrun/auto", messages)
 
 | Profile | Behavior | Best For |
 |---------|----------|----------|
-| `"free"` | Only the <!-- br:models.free -->5<!-- /br:models.free --> $0 NVIDIA models — no wallet needed | Development, testing |
+| `"free"` | Only the 5 $0 NVIDIA models — no wallet needed | Development, testing |
 | `"eco"` | Cheapest capable model per tier | Bulk processing |
 | `"auto"` | Balances quality and cost (default) | Production workloads |
 | `"premium"` | Top-tier models | Critical tasks |
@@ -207,7 +207,7 @@ result = client.smart_chat("Review this contract for legal issues...", routing_p
 
 ### Capability tiers
 
-The classifier places every request in one of <!-- br:clawrouter.tiers -->4<!-- /br:clawrouter.tiers --> tiers. Under `auto`, the tier primary is the starting point — the portfolio then ranks the eligible candidates and may promote a better-suited model for the task.
+The classifier places every request in one of 4 tiers. Under `auto`, the tier primary is the starting point — the portfolio then ranks the eligible candidates and may promote a better-suited model for the task.
 
 | Tier | Auto primary | Use Case |
 |------|--------------|----------|

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -130,7 +130,7 @@ console.log(`Paying from: ${address}`);
 
 **Save 88% on LLM costs automatically.**
 
-The `smartChat()` method routes each request on [Router Core](https://github.com/BlockRunAI/router-core) — <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions --> weighted dimensions classify the request, capability constraints are applied as hard filters, and the surviving candidates are ranked on task affinity, cost, speed and reliability. Decisions run locally in <1ms — your prompts never leave your machine for routing, and no extra model call is made to decide.
+The `smartChat()` method routes each request on [Router Core](https://github.com/BlockRunAI/router-core) — 15 weighted dimensions classify the request, capability constraints are applied as hard filters, and the surviving candidates are ranked on task affinity, cost, speed and reliability. Decisions run locally in <1ms — your prompts never leave your machine for routing, and no extra model call is made to decide.
 
 ### Basic Usage
 

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -141,7 +141,7 @@ print(f"Paying from: {address}")
 
 **Save up to 94% on LLM costs automatically.**
 
-The `smart_chat()` method routes each request on [Router Core](https://github.com/BlockRunAI/router-core) — <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions --> weighted dimensions classify the request, capability constraints are applied as hard filters, and the surviving candidates are ranked on task affinity, cost, speed and reliability. Decisions run locally in <1ms — your prompts never leave your machine for routing, and no extra model call is made to decide.
+The `smart_chat()` method routes each request on [Router Core](https://github.com/BlockRunAI/router-core) — 15 weighted dimensions classify the request, capability constraints are applied as hard filters, and the surviving candidates are ranked on task affinity, cost, speed and reliability. Decisions run locally in <1ms — your prompts never leave your machine for routing, and no extra model call is made to decide.
 
 ### Basic Usage
 


### PR DESCRIPTION
#50 added 12 `<!-- br:x -->N<!-- /br:x -->` markers across 5 files. **This tree cannot carry them.**

Markers are inert only where something renders the markdown as HTML and drops comments. blockrun's docs renderer **escapes** the comment onto the page, so a reader sees the literal `<!-- br:models.free -->` in the text.

blockrun asserts exactly this, in `brand-numbers.docs.test.ts`: *"carries no br: markers — this renderer escapes them into view"*.

## Why #50 looked fine

blockrun consumes this repo as a **submodule pinned to an older commit**. #50 could sit on `main` perfectly green while being unshippable, because nothing referenced it yet. It only turned red when a pointer bump pulled it in — blockrun#397, the GLM-5.3 launch, which is how this surfaced at all.

That is worth knowing beyond this fix: **green CI here does not mean shippable**, because the consumer pins. Anything that depends on how blockrun renders these files is only validated at pointer-bump time.

## The fix

Strip the wrapper, keep the value. `docs/` goes back to plain numbers and the **test** is what catches staleness — the same trade already made for `public/*.md`, `llms.txt`, `package.json` descriptions and shields badges, none of which markers can reach either.

12 markers, 5 files, values unchanged. blockrun's docs guard passes against this commit.