### PR TITLE
Add Entropy Index — regime gate Data Provider (x402 Base USDC)

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -46,6 +46,7 @@ BlockRun works with the x402 facilitator network:
 | [x402 Foundation](https://x402.org) | Protocol development |
 | [thirdweb](https://thirdweb.com) | Wallet & payment infrastructure |
 | [Predexon](https://predexon.com) | Prediction market data (Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance) |
+| [Entropy Index](https://www.entropyindex.com) | Regime / risk gate — heat check before size ($0.25 Base USDC x402); complementary to PM data |
 | [Modal](https://modal.com) | Sandbox compute (managed Python sandboxes for isolated code execution) |
 
 ## Community Integrations

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Built into both Python and TypeScript SDKs. Also available as standalone: [ClawR
 |---------|---------|-------------|
 | [Exa](https://exa.ai) | Web Search | Neural web search, find-similar, page contents, AI-grounded answers |
 | [Predexon](https://predexon.com) | Prediction Markets | Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, Binance Futures data |
+| [Entropy Index](https://www.entropyindex.com) | Regime / risk | Pre-action regime gate for agentic capital — heat check before size ($0.25 Base USDC x402). |
 | [Modal](https://modal.com) | Sandbox Compute | Managed Python sandboxes for isolated code execution |
 
 ### x402 Facilitators


### PR DESCRIPTION
## Data Provider ask — Entropy Index (Predexon-style pass-through)

### Ask
List **Entropy Index** as a Data Provider with the same commercial shape as Predexon:
- BlockRun proxies our x402 faces
- Agents pay USDC per call from wallets they already fund on BlockRun
- **0% BlockRun margin** — settle to our Base `payTo`
- Listed under Data / Risk (or new "Regime" category)

### Why it fits
Agents already buy LLMs, PM data (Predexon), and crypto data (Surf) on BlockRun. Missing SKU: **checkbox before capital moves** — regime / geopolitical + crypto stress context before size / widen / leverage.

### Lead SKU
`GET https://www.entropyindex.com/api/v1/risk/global-financial-system?depth=probe`
→ **$0.25 USDC on Base** (`eip155:8453`)

Free hitch: `GET https://www.entropyindex.com/api/v1/x402/pre-settle`

### Machine doors
- https://www.entropyindex.com/.well-known/x402.json
- https://www.entropyindex.com/llms.txt
- https://www.entropyindex.com/.well-known/regime-gate-mcp.json
- Catalog: https://www.entropyindex.com/x402
- Status: https://www.entropyindex.com/api/v1/x402/status

### Suggested README / ECOSYSTEM row
| [Entropy Index](https://www.entropyindex.com) | Regime / risk | Pre-action regime gate for agentic capital — heat check before size ($0.25 Base USDC x402). |

### Proof lead
Our Index hit Crisis mode by March 2008 — 6 months before Lehman. Not a trade signal.

Happy to wire OpenAPI / payTo confirmation if you share the Data Provider template. Also opening a PR to add the Data Partners row.
