### PR TITLE
docs: intro description under 160 chars

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: BlockRun is economic infrastructure for the agent era — AI agents discover services, pay in USDC over x402, and execute autonomously with no API keys and no subscriptions.
+description: BlockRun is the routing and payment layer for AI agents — one endpoint for every model and tool, paid per call in USDC with no API keys or subscriptions.
 ---
 
 # What is BlockRun?


### PR DESCRIPTION
Frontmatter `description` on `docs/README.md` was 171 chars (Google truncates ~160) and used the pre-repositioning "economic infrastructure" framing. Now 153 chars, routing + payment.

Found by the 2026-08-28 sitewide SEO crawl in blockrun#425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)