### PR TITLE
docs(responses): fix the SDKs link (../sdks/README.md does not exist)

### DIFF
--- a/docs/api-reference/responses.md
+++ b/docs/api-reference/responses.md
@@ -60,7 +60,7 @@ All paid OpenAI models: GPT-5.x (including `-pro` tiers), o-series, and the code
 
 ## Payment flow
 
-Identical to Chat Completions: send the request without payment, receive a `402` with a USDC quote (estimated input tokens + 10% of `max_output_tokens`, minimum $0.003), sign the x402 authorization, and resend with the `PAYMENT-SIGNATURE` header. The [SDKs](../sdks/README.md) handle this automatically.
+Identical to Chat Completions: send the request without payment, receive a `402` with a USDC quote (estimated input tokens + 10% of `max_output_tokens`, minimum $0.003), sign the x402 authorization, and resend with the `PAYMENT-SIGNATURE` header. The [SDKs](../getting-started/sdk-developers.md) handle this automatically.
 
 ## Examples
 


### PR DESCRIPTION
`api-reference/responses.md` linked `../sdks/README.md`. That file does not exist — `sdks/` holds only `python.md`, `typescript.md`, `go.md`, `xrpl.md` — so on blockrun.ai/docs it rendered as `/docs/sdks`, a 404. Repointed at `getting-started/sdk-developers.md`, the SDK overview page SUMMARY already lists.

Found by the site-side internal-link sweep (3,483 docs links checked; this was the one left).