### PR TITLE
docs: sweep every page against what the gateway ships on 2026-08-29

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,7 @@ Four product families, one payment layer.
 :::
 
 :::card{title="Routing" href="products/routing/clawrouter.md" icon="Route"}
-ClawRouter scores each prompt and picks the cheapest model that can handle it — up to **78% lower** LLM cost.
+ClawRouter scores each prompt and picks the cheapest model that can handle it — **88% lower** LLM cost on the auto profile (98% on eco) versus pinning Claude Opus 5 for every request.
 :::
 
 :::card{title="Creation" href="products/creation/nano-banana.md" icon="Image"}
@@ -91,6 +91,6 @@ No API keys to rotate, no subscriptions to cancel, no per-provider signups. Just
 
 - **Website:** [blockrun.ai](https://blockrun.ai)
 - **GitHub:** [github.com/BlockRunAI](https://github.com/BlockRunAI)
-- **x402 Services:** [live service directory](https://blockrun.ai/ecosystem/services)
+- **x402 Services:** [live service directory](https://blockrun.ai/models)
 - **Every public repo:** [Ecosystem](resources/ecosystem.md) — routers, plugins, SDKs, Franklin apps, skills
 - **Enterprise (API keys + wire billing):** user.blockrun.ai — sign-in coming soon

--- a/docs/api-reference/chat-completions.md
+++ b/docs/api-reference/chat-completions.md
@@ -153,8 +153,8 @@ BlockRun does **not** prepend a hidden identity/system directive to your prompt 
 If you use the Claude-native `POST /v1/messages` endpoint with the `context_management` field, you **must** also send the matching `anthropic-beta` header. A `context_management` body without that header is rejected at the edge with a `400` (rather than silently ignored).
 :::
 
-:::note{title="Sampling params on Claude Opus 5 / 4.8 / 4.7"}
-`temperature`, `top_p`, and `top_k` are **not honored** for `anthropic/claude-opus-5`, `anthropic/claude-opus-4.8`, and `anthropic/claude-opus-4.7` — these models reject sampling params upstream, so the gateway strips them so your request still succeeds (it does not fail). Set behavior through your prompt instead.
+:::note{title="Sampling params on Claude Opus 5 / 4.8 / 4.7, Fable 5 and Sonnet 5"}
+`temperature`, `top_p`, and `top_k` are **not honored** for `anthropic/claude-opus-5`, `anthropic/claude-fable-5`, `anthropic/claude-sonnet-5`, `anthropic/claude-opus-4.8`, and `anthropic/claude-opus-4.7` — these models reject sampling params upstream, so the gateway strips them so your request still succeeds (it does not fail). Set behavior through your prompt instead.
 :::
 
 ### Payment Required (402)

--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -67,23 +67,23 @@ Narrow your search to a specific type of content:
 
 ```json
 {
-  "data": {
-    "requestId": "d581de9ed6d77165",
-    "resolvedSearchType": "neural",
-    "results": [
-      {
-        "id": "https://github.com/example/x402-impl",
-        "title": "x402 Payment Protocol — Reference Implementation",
-        "url": "https://github.com/example/x402-impl",
-        "publishedDate": "2026-03-15T00:00:00.000Z",
-        "score": 0.94
-      }
-    ],
-    "searchTime": 860,
-    "costDollars": { "total": 0.007 }
-  }
+  "requestId": "d581de9ed6d77165",
+  "resolvedSearchType": "neural",
+  "results": [
+    {
+      "id": "https://github.com/example/x402-impl",
+      "title": "x402 Payment Protocol — Reference Implementation",
+      "url": "https://github.com/example/x402-impl",
+      "publishedDate": "2026-03-15T00:00:00.000Z",
+      "score": 0.94
+    }
+  ],
+  "searchTime": 860,
+  "costDollars": { "total": 0.007 }
 }
 ```
+
+The gateway returns Exa's JSON body verbatim — there is no `data` wrapper.
 
 ---
 
@@ -103,17 +103,15 @@ Best for: "What is X?", "How does Y work?", "What's the current state of Z?"
 
 ```json
 {
-  "data": {
-    "requestId": "601e412c9b1d0891",
-    "answer": "x402 is an open payment standard built around the HTTP 402 status code...",
-    "citations": [
-      {
-        "id": "https://x402.org",
-        "title": "x402 - Payment Required | Internet-Native Payments Standard",
-        "url": "https://www.x402.org"
-      }
-    ]
-  }
+  "requestId": "601e412c9b1d0891",
+  "answer": "x402 is an open payment standard built around the HTTP 402 status code...",
+  "citations": [
+    {
+      "id": "https://x402.org",
+      "title": "x402 - Payment Required | Internet-Native Payments Standard",
+      "url": "https://www.x402.org"
+    }
+  ]
 }
 ```
 
@@ -137,18 +135,16 @@ costs $0.021; a single page costs $0.003.
 
 ```json
 {
-  "data": {
-    "results": [
-      {
-        "id": "https://x402.org",
-        "url": "https://x402.org",
-        "title": "x402 - Payment Required",
-        "text": "x402 is an open, neutral standard for internet-native payments...",
-        "author": null
-      }
-    ],
-    "costDollars": { "total": 0.002 }
-  }
+  "results": [
+    {
+      "id": "https://x402.org",
+      "url": "https://x402.org",
+      "title": "x402 - Payment Required",
+      "text": "x402 is an open, neutral standard for internet-native payments...",
+      "author": null
+    }
+  ],
+  "costDollars": { "total": 0.002 }
 }
 ```
 
@@ -223,7 +219,7 @@ const similar = await client.exaFindSimilar("https://blockrun.ai", {
 
 ### 4. Developer Agent — Find Code Examples
 
-AI coding agent looking for real implementation examples. Cost: $0.016.
+AI coding agent looking for real implementation examples. Cost: $0.014 (one search at $0.011 + one URL of contents at $0.003).
 
 ```typescript
 // Find GitHub repos implementing a specific pattern

--- a/docs/api-reference/market-data.md
+++ b/docs/api-reference/market-data.md
@@ -113,7 +113,7 @@ once a payment header is attached.
 
 ## Discovery
 
-Free endpoints answer `HEAD` and `OPTIONS` with a `402` whose body is x402
+Free endpoints answer `HEAD` with a `402` whose body is x402
 discovery metadata (`"error": "Payment Required (discovery)"`, `free: true`,
 amount `0`) so indexers can register them — that is not a charge. A plain
 `GET` returns `200` and the data.

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -1,6 +1,6 @@
 ---
 title: Models
-description: List and price 72 chat, image, video, music and speech models from one BlockRun API — provider rates, no margin on chat tokens, $0.001 per call.
+description: List and price 71 chat, image, video, music and speech models from one BlockRun API — provider rates, no margin on chat tokens, $0.001 per call.
 ---
 
 # Models
@@ -22,32 +22,36 @@ Each model object in the response includes:
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string | Model identifier (e.g., `openai/gpt-5.5`) |
+| `object` | string | Always `"model"` (OpenAI-compatible envelope) |
+| `owned_by` | string | Model maker (e.g., `openai`, `anthropic`, `xai`) |
 | `name` | string | Display name (e.g., "GPT-5.5") |
 | `description` | string | Model description |
-| `provider` | string | Provider name |
-| `inputPrice` | number | Input price per 1M tokens |
-| `outputPrice` | number | Output price per 1M tokens |
 | `context_window` | number | Context window size in tokens |
 | `max_output` | number | Maximum output tokens |
-| `categories` | string[] | Model capabilities: `"chat"`, `"reasoning"`, `"coding"`, `"vision"` |
-| `available` | boolean | Whether the model is currently available |
+| `categories` | string[] | Model capabilities: `"chat"`, `"reasoning"`, `"coding"`, `"vision"` (image / video / audio rows carry `"image"`, `"video"`, `"audio"`, `"speech"`, `"sound-effects"`) |
+| `billing_mode` | string | `"paid"` (per-token), `"flat"` (per-request), `"free"`, or a media mode such as `"per_image"` |
+| `pricing` | object | `{ input, output }` in USD per 1M tokens for per-token models; `{ flat }` for flat-priced models (fee-inclusive); `{ per_image }`, `{ per_second }`, etc. for media |
+
+Only models that are currently available are returned — there is no `available` flag to check.
 
 ### Example Response
 
 ```json
 {
-  "models": [
+  "object": "list",
+  "data": [
     {
       "id": "openai/gpt-5.5",
+      "object": "model",
+      "created": 1700000000,
+      "owned_by": "openai",
       "name": "GPT-5.5",
       "description": "OpenAI's flagship — first fully retrained base since GPT-4.5; 1M context, 128K output, native agent + computer use",
-      "provider": "openai",
-      "inputPrice": 5.00,
-      "outputPrice": 30.00,
       "context_window": 1050000,
       "max_output": 128000,
       "categories": ["chat", "coding", "vision"],
-      "available": true
+      "billing_mode": "paid",
+      "pricing": { "input": 5.00, "output": 30.00 }
     }
   ]
 }
@@ -56,7 +60,7 @@ Each model object in the response includes:
 ## Available Models (chat / image / video / music / speech / sound effects)
 
 :::note
-**70 chat / LLM models** are publicly listed on mainnet, plus **9 image**, **8 video**, **1 music**, **5 text-to-speech**, and **1 sound-effects** model — covering chat, image, video, music, speech, and sound-effects generation from one API. Additional deprecated / superseded LLM IDs remain routable for backwards compatibility but are hidden from the catalog. Call `GET /api/v1/models` for the exact live list.
+**71 chat / LLM models** are publicly listed on mainnet, plus **9 image**, **8 video**, **1 music**, **5 text-to-speech**, and **1 sound-effects** model — covering chat, image, video, music, speech, and sound-effects generation from one API. Additional deprecated / superseded LLM IDs remain routable for backwards compatibility but are hidden from the catalog. Call `GET /api/v1/models` for the exact live list.
 :::
 
 All prices shown are provider rates — and, for per-token chat, also the billed rates: BlockRun adds **no platform margin** on chat tokens (we match OpenRouter), only the flat $0.001/request transaction fee. Media and Live Search still carry a 5% platform fee.
@@ -99,7 +103,6 @@ Released 2026-04-23 — first fully retrained base since GPT-4.5.
 |----------|------|-------------|--------------|---------|
 | `openai/gpt-5.2-pro` | GPT-5.2 Pro | $21.00/M | $168.00/M | 400K |
 | `openai/gpt-5.2` | GPT-5.2 | $1.75/M | $14.00/M | 400K |
-| `openai/gpt-5.3` | GPT-5.3 | $1.75/M | $14.00/M | 128K |
 | `openai/gpt-5.3-codex` | GPT-5.3 Codex | $1.75/M | $14.00/M | 400K |
 | `openai/gpt-5-mini` | GPT-5 Mini | $0.25/M | $2.00/M | 200K |
 
@@ -136,8 +139,8 @@ Released 2026-04-23 — first fully retrained base since GPT-4.5.
 | `anthropic/claude-sonnet-5` | Claude Sonnet 5 | $3.00/M | $15.00/M | 1M |
 | `anthropic/claude-haiku-4.5` | Claude Haiku 4.5 | $1.00/M | $5.00/M | 200K |
 
-:::warning{title="Opus 4.7 / 4.8 behavior"}
-These flagship models reject all sampling parameters (`temperature`, `top_p`, `top_k`); the gateway drops them so calls succeed. They use adaptive thinking (built-in, not API-configurable). The model may decline a request with HTTP 200 and `stop_reason: "refusal"` (`finish_reason: "content_filter"` on the OpenAI-compatible endpoint) — check the stop reason before reading content.
+:::warning{title="Claude Opus 4.7 / 4.8 / 5, Fable 5 and Sonnet 5 behavior"}
+These models reject all sampling parameters (`temperature`, `top_p`, `top_k`); the gateway drops them so calls succeed. They use adaptive thinking (built-in, not API-configurable). The model may decline a request with HTTP 200 and `stop_reason: "refusal"` (`finish_reason: "content_filter"` on the OpenAI-compatible endpoint) — check the stop reason before reading content.
 :::
 
 ### Google Gemini
@@ -162,7 +165,7 @@ Gemini **Pro** models (`gemini-2.5-pro`, `gemini-3.1-pro`) bill a **long-context
 |----------|------|-------------|--------------|---------|
 | `xai/grok-4.5` | Grok 4.5 | $2.50/M | $9.00/M | 500K |
 | `xai/grok-4.3` | Grok 4.3 | $1.50/M | $4.00/M | 1M |
-| `xai/grok-build-0.1` | Grok Build 0.1 | $1.50/M | $3.00/M | 250K |
+| `xai/grok-build-0.1` | Grok Build 0.1 | $1.50/M | $3.00/M | 256K |
 
 Grok bills a **long-context tier** at 2x the rates above once a request's prompt reaches 200K tokens (mirrors xAI's official pricing — e.g. Grok 4.5 is $5.00/M in · $18.00/M out above the threshold). Live Search adds $0.025 per source used. Grok Imagine image/video SKUs are listed under Image / Video Generation below.
 
@@ -178,7 +181,6 @@ Grok bills a **long-context tier** at 2x the rates above once a request's prompt
 
 | Model ID | Name | Input Price | Output Price | Context |
 |----------|------|-------------|--------------|---------|
-| `zai/glm-5-code` | GLM-5 Code | $1.20/M | $5.00/M | 200K |
 | `zai/glm-5.1` | GLM-5.1 | $1.40/M | $4.40/M | 200K |
 | `zai/glm-5.2` | GLM-5.2 | $1.40/M | $4.40/M | 1M |
 | `zai/glm-5.3` | GLM-5.3 | $1.40/M | $4.40/M | 1M |
@@ -244,15 +246,18 @@ Open-weight models served free of charge (no x402 payment), subject to a small p
 
 ### Image Generation
 
+Media prices below include the 5% media margin; the flat $0.001 transaction fee is added per call.
+
 | Model ID | Name | Price |
 |----------|------|-------|
-| `openai/gpt-image-1` | GPT Image 1 | $0.02-0.04/image |
-| `openai/gpt-image-2` | ChatGPT Images 2.0 | $0.06-0.12/image |
-| `google/nano-banana` | Nano Banana | $0.05/image |
-| `google/nano-banana-pro` | Nano Banana Pro | $0.10-0.15/image |
-| `xai/grok-imagine-image` | Grok Imagine | $0.02/image |
-| `xai/grok-imagine-image-pro` | Grok Imagine Pro | $0.07/image |
-| `zai/cogview-4` | CogView-4 | $0.015-0.02/image |
+| `openai/gpt-image-1` | GPT Image 1 | $0.021-0.042/image |
+| `openai/gpt-image-2` | ChatGPT Images 2.0 | $0.063-0.126/image |
+| `google/nano-banana` | Nano Banana | $0.0525/image |
+| `google/nano-banana-2` | Nano Banana 2 | $0.0945/image |
+| `google/nano-banana-pro` | Nano Banana Pro | $0.105-0.1575/image |
+| `xai/grok-imagine-image` | Grok Imagine | $0.021/image |
+| `xai/grok-imagine-image-pro` | Grok Imagine Pro | $0.0735/image |
+| `zai/cogview-4` | CogView-4 | $0.01575-0.021/image |
 | `bytedance/seedream-5-pro` | Seedream 5.0 Pro | $0.047-0.095/image (async, ~2 min) |
 
 ### Video Generation
@@ -264,6 +269,7 @@ Seedance defaults to **720p with synced audio** for text-to-video; pass `resolut
 | `xai/grok-imagine-video` | Grok Imagine Video | $0.05/sec @480p default · $0.07/sec @720p, + $0.001/generation (8s 480p = $0.401) | 15s |
 | `xai/grok-imagine-video-1.5` | Grok Imagine Video 1.5 | $0.08/sec @480p default · $0.14/sec @720p · $0.25/sec @1080p, + $0.001/generation (8s 480p = $0.641) | 15s |
 | `bytedance/seedance-1.5-pro` | Seedance 1.5 Pro | ~$0.070/sec ($0.35 / 5s clip) | 12s |
+| `bytedance/seedance-2.0-mini` | Seedance 2.0 Mini | ~$0.080/sec ($0.40 / 5s clip) | 15s |
 | `bytedance/seedance-2.0-fast` | Seedance 2.0 Fast | ~$0.165/sec ($0.83 / 5s clip) | 15s |
 | `bytedance/seedance-2.0` | Seedance 2.0 Pro | ~$0.227/sec ($1.14 / 5s clip) | 15s |
 | `bytedance/seedance-2.5` | Seedance 2.5 | ~$0.315/sec ($1.58 / 5s clip) | 30s |
@@ -311,7 +317,8 @@ client = LLMClient()
 models = client.list_models()
 
 for model in models:
-    print(f"{model['id']}: ${model['inputPrice']}/M input, context: {model['context_window']}")
+    pricing = model.get("pricing", {})
+    print(f"{model['id']}: ${pricing.get('input')}/M input, context: {model['context_window']}")
     print(f"  Categories: {', '.join(model.get('categories', []))}")
 ```
 :::

--- a/docs/api-reference/multi-chain-rpc.md
+++ b/docs/api-reference/multi-chain-rpc.md
@@ -27,7 +27,7 @@ Swap `{network}` for the chain. Body is a standard JSON-RPC 2.0 request; the res
 A request with no payment header returns `402 Payment Required` with the exact $0.003 quote (`price.amount: "0.0030"`, scaled ×N for a batch) and Base USDC instructions. The x402 requirements are in the `X-Payment-Required` / `PAYMENT-REQUIRED` headers (base64) and `WWW-Authenticate: X402 requirements="…"`. Re-send with the signed authorization in `X-Payment` (or `Payment-Signature`) to get the result.
 :::
 
-## Supported networks (40+)
+## Supported networks (40)
 
 EVM and non-EVM, one path each. A selection:
 

--- a/docs/api-reference/prediction-markets.md
+++ b/docs/api-reference/prediction-markets.md
@@ -279,7 +279,7 @@ GET https://blockrun.ai/api/v1/pm/markets/search
 
 ```bash
 curl "https://blockrun.ai/api/v1/pm/markets/search?q=bitcoin%202026"
-curl "https://blockrun.ai/api/v1/pm/markets/search?q=election&platform=kalshi"
+curl "https://blockrun.ai/api/v1/pm/markets/search?q=election&venue=kalshi"
 ```
 
 Searches Polymarket, Kalshi, Limitless, Opinion and Predict.Fun in one call.
@@ -325,7 +325,7 @@ candles = client.pm("binance/candles/BTCUSDT", interval="1h", limit=24)
 
 :::tab{label="TypeScript"}
 ```typescript
-import { LLMClient } from "blockrun-llm";
+import { LLMClient } from "@blockrun/llm";
 
 const client = new LLMClient();
 

--- a/docs/api-reference/realface.md
+++ b/docs/api-reference/realface.md
@@ -1,11 +1,11 @@
 ---
 title: RealFace Enrollment
-description: Enroll a real person's face (no KYC, ~1-min on-phone liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0-fast videos.
+description: Enroll a real person's face (no KYC, ~1-min on-phone liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0 Fast / 2.0 Mini videos.
 ---
 
 # RealFace Enrollment
 
-Enroll a real person's face as a `ta_xxxxxxxx` asset you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0-fast call. Use this when you want **a real person to appear consistently across multiple videos** (talking head, spokesperson, character continuity).
+Enroll a real person's face as a `ta_xxxxxxxx` asset you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0 Fast / 2.0 Mini call. Use this when you want **a real person to appear consistently across multiple videos** (talking head, spokesperson, character continuity).
 
 :::note{title="No KYC required"}
 No government ID, no account login, no name verification. Just a brief on-phone liveness check (nod + blink, ~1 minute) that proves the person enrolling is the same as the person in the photo. The biometric data is processed by the upstream identity service — BlockRun never sees it. For purely AI-generated characters (no real person involved), use [Virtual Portrait](virtual-portrait.md) instead ($0.011, no liveness step).
@@ -17,7 +17,7 @@ No government ID, no account login, no name verification. Just a brief on-phone 
 | **Price** | **$0.011 USDC** per enrollment, one-time, settled to BlockRun's Base wallet via x402 |
 | **Auth** | x402 micropayment header on finalize — no API key needed |
 | **Network** | Base (USDC, EIP-3009 `exact`) |
-| **Returns** | `ta_xxxxxxxx…` asset id, usable as `real_face_asset_id` on Seedance 2.0 / 2.0-fast |
+| **Returns** | `ta_xxxxxxxx…` asset id, usable as `real_face_asset_id` on Seedance 2.0 / 2.0 Fast / 2.0 Mini |
 
 You can use the web UI at [blockrun.ai/studio/realface](https://blockrun.ai/studio/realface) — connect wallet, paste image URL, get QR for the rights-holder to scan, pay $0.011, copy the `ta_xxx`. The endpoints below are for SDK / programmatic use.
 
@@ -207,7 +207,7 @@ If settlement itself fails after a successful enrollment, BlockRun absorbs the c
   "image_url": "https://example.com/person.jpg",
   "created_at": "2026-05-24T16:19:00.000Z",
   "usage": {
-    "compatible_models": ["bytedance/seedance-2.0", "bytedance/seedance-2.0-fast"],
+    "compatible_models": ["bytedance/seedance-2.0", "bytedance/seedance-2.0-fast", "bytedance/seedance-2.0-mini"],
     "how_to_use": "Pass \"real_face_asset_id\": \"ta_f85b20b9394e47be9502d819bee7929c\" on a Seedance video generation request."
   },
   "price": { "amount": "0.0110", "currency": "USD" },
@@ -226,7 +226,7 @@ The settlement receipt is also returned in the `X-Payment-Response` / `PAYMENT-R
 
 ## Using the enrolled ta_xxx
 
-Pass it as `real_face_asset_id` on any Seedance 2.0 / 2.0-fast call:
+Pass it as `real_face_asset_id` on any Seedance 2.0 / 2.0 Fast / 2.0 Mini call:
 
 ```bash
 curl -X POST http://localhost:8402/v1/videos/generations \
@@ -297,14 +297,14 @@ The video playground reads this same list and shows it in the `real_face_asset_i
 | Liveness check | Not required | Required (~1 minute on phone) |
 | Upstream verification | None | Biometric match against H5 live face |
 | KYC / government ID | Not required | Not required |
-| Compatible models | Seedance 2.0 / 2.0-fast | Seedance 2.0 / 2.0-fast |
+| Compatible models | Seedance 2.0 / 2.0 Fast / 2.0 Mini | Seedance 2.0 / 2.0 Fast / 2.0 Mini |
 
 ## What's next?
 
 ::::cards
 
 :::card{title="Video Generation" href="video-generation.md" icon="Image"}
-Pass the `ta_xxx` you just enrolled as `real_face_asset_id` on a Seedance 2.0 / 2.0-fast call.
+Pass the `ta_xxx` you just enrolled as `real_face_asset_id` on a Seedance 2.0 / 2.0 Fast / 2.0 Mini call.
 :::
 
 :::card{title="Virtual Portrait" href="virtual-portrait.md" icon="Boxes"}

--- a/docs/api-reference/responses.md
+++ b/docs/api-reference/responses.md
@@ -59,7 +59,7 @@ Missing `model`, or a body with neither `input` nor `instructions`, is a `400`. 
 
 ## Supported models
 
-All paid OpenAI models: GPT-5.x (including `-pro` tiers), o-series, and the codex family. `GET /v1/models` lists current IDs and prices; the `openai/` prefix is optional. Other providers (Claude, Gemini, DeepSeek, …) are served via [Chat Completions](chat-completions.md) and [Anthropic Messages](chat-completions.md#anthropic-compatible-endpoint).
+All paid OpenAI models: GPT-5.x (including `-pro` tiers), o-series, and the codex family. `GET /v1/models` lists current IDs and prices; the `openai/` prefix is optional. Other providers (Claude, Gemini, DeepSeek, …) are served via [Chat Completions](chat-completions.md) and the Anthropic-compatible `POST /api/v1/messages` endpoint.
 
 ## Payment flow
 
@@ -75,7 +75,7 @@ The quote is estimated input tokens plus **10% of `max_output_tokens`** at the m
 }
 ```
 
-The signed requirements are in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers; the header amount is authoritative and includes the transaction fee (the body `price.amount` on this endpoint is the pre-fee quote). A payment that fails verification is a `402` in the same OpenAI envelope — `"Payment verification failed: …"` — and a reused authorization is `402` `"Payment authorization already used — sign a fresh authorization for each request."`; this endpoint keeps OpenAI's error schema rather than the `code` field the native BlockRun endpoints carry. Nothing is charged on either.
+The signed requirements are in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers; the header amount is authoritative and includes the transaction fee, and the body `price.amount` quotes the same fee-inclusive number. A payment that fails verification is a `402` in the same OpenAI envelope — `"Payment verification failed: …"` — and a reused authorization is `402` `"Payment authorization already used — sign a fresh authorization for each request."`; this endpoint keeps OpenAI's error schema rather than the `code` field the native BlockRun endpoints carry. Nothing is charged on either.
 
 ## Examples
 

--- a/docs/api-reference/search.md
+++ b/docs/api-reference/search.md
@@ -48,11 +48,8 @@ POST https://blockrun.ai/api/v1/search
   "query": "latest AI funding rounds",
   "summary": "Several major AI companies have announced significant funding rounds...",
   "citations": [
-    {
-      "url": "https://techcrunch.com/ai-startup-series-b",
-      "title": "AI Startup raises $50M Series B",
-      "source": "web"
-    }
+    "https://techcrunch.com/ai-startup-series-b",
+    "https://www.reuters.com/technology/ai-funding-round"
   ],
   "sources_used": 10,
   "model": "xai/grok-3-mini"
@@ -65,10 +62,7 @@ POST https://blockrun.ai/api/v1/search
 |-------|------|-------------|
 | `query` | string | The original search query |
 | `summary` | string | AI-generated summary of search results with citations |
-| `citations` | array | Array of source citations |
-| `citations[].url` | string | URL of the cited source |
-| `citations[].title` | string | Title or description of the source |
-| `citations[].source` | string | Source type (`web`, `news`) |
+| `citations` | string[] | Source URLs cited by the summary, in citation order. Plain URL strings — there are no title/source sub-fields. |
 | `sources_used` | integer | Number of sources actually queried (falls back to `max_results` when upstream does not report it) |
 | `model` | string | Model used for search (currently `xai/grok-3-mini`) |
 
@@ -224,7 +218,7 @@ You can also access Grok's live search through the Chat Completions API by inclu
 
 ```json
 {
-  "model": "xai/grok-3-mini",
+  "model": "xai/grok-4.3",
   "messages": [{"role": "user", "content": "What's trending in AI today?"}],
   "search_parameters": {
     "mode": "on",

--- a/docs/api-reference/surf.md
+++ b/docs/api-reference/surf.md
@@ -121,20 +121,20 @@ The SQL endpoint runs against Surf's ClickHouse cluster — 80+ tables across Et
 
 :::tab{label="TypeScript"}
 ```typescript
-import { LLMClient } from '@blockrun/llm';
+import { SurfClient } from '@blockrun/llm';
 
-const client = new LLMClient({ privateKey: process.env.BASE_CHAIN_WALLET_KEY });
+const surf = new SurfClient({ privateKey: process.env.BASE_CHAIN_WALLET_KEY });
 
 // Simple price lookup
-const btc = await client.surf('GET', 'market/price', { symbol: 'BTC' });
+const btc = await surf.get('market/price', { symbol: 'BTC' });
 
 // Time-series funding history
-const funding = await client.surf('GET', 'exchange/funding-history', {
+const funding = await surf.get('exchange/funding-history', {
   pair: 'BTC-USDT-PERP',
 });
 
 // Raw SQL
-const flows = await client.surf('POST', 'onchain/sql', {
+const flows = await surf.post('onchain/sql', {
   query: 'SELECT chain, sum(value_usd) FROM bridge_tx WHERE block_time > now() - INTERVAL 7 DAY GROUP BY chain',
 });
 ```
@@ -142,20 +142,20 @@ const flows = await client.surf('POST', 'onchain/sql', {
 
 :::tab{label="Python"}
 ```python
-from blockrun_llm import LLMClient
+from blockrun_llm import SurfClient
 
-client = LLMClient()
+surf = SurfClient()
 
 # Simple price lookup
-btc = client.surf('GET', 'market/price', {'symbol': 'BTC'})
+btc = surf.get('market/price', {'symbol': 'BTC'})
 
 # Polymarket position lookup for a wallet
-pos = client.surf('GET', 'prediction-market/polymarket/positions',
-                  {'address': '0xCC8c44AD3dc2A58D841c3EB26131E49b22665EF8'})
+pos = surf.get('prediction-market/polymarket/positions',
+               {'address': '0xCC8c44AD3dc2A58D841c3EB26131E49b22665EF8'})
 
 # Raw on-chain SQL
-result = client.surf('POST', 'onchain/sql',
-                     {'query': 'SELECT count() FROM tx WHERE chain = \'base\''})
+result = surf.post('onchain/sql',
+                   {'query': 'SELECT count() FROM tx WHERE chain = \'base\''})
 ```
 :::
 
@@ -177,9 +177,9 @@ The `blockrun_surf` MCP tool ships with [BlockRun MCP](../mcp/blockrun-mcp.md). 
 
 ```typescript
 const [price, fng, funding] = await Promise.all([
-  client.surf('GET', 'market/price', { symbol: 'BTC' }),       // $0.0085
-  client.surf('GET', 'market/fear-greed'),                      // $0.0085
-  client.surf('GET', 'exchange/funding-history', { pair: 'BTC-USDT-PERP' }), // $0.0085
+  surf.get('market/price', { symbol: 'BTC' }),       // $0.0085
+  surf.get('market/fear-greed'),                      // $0.0085
+  surf.get('exchange/funding-history', { pair: 'BTC-USDT-PERP' }), // $0.0085
 ]);
 ```
 
@@ -188,8 +188,8 @@ Total cost: $0.0255 per pre-trade snapshot (three calls at $0.0085). Cheap enoug
 ### 2. Smart-money wallet monitor ($0.017/wallet)
 
 ```python
-profile = client.surf('GET', 'wallet/detail', {'address': addr})
-positions = client.surf('GET', 'prediction-market/polymarket/positions', {'address': addr})
+profile = surf.get('wallet/detail', {'address': addr})
+positions = surf.get('prediction-market/polymarket/positions', {'address': addr})
 ```
 
 Pipe into an LLM to summarize: *"Wallet X (smart-money DeFi whale) opened a $200K Polymarket position on the Fed Dec rate cut."*
@@ -211,8 +211,8 @@ A weekly research bot that runs this twice and feeds the result into Claude Opus
 ### 4. Multi-source prediction-market aggregator (Tier 1, ~$0.0085/event)
 
 ```python
-poly = client.surf('GET', 'prediction-market/polymarket/markets', {'market_slug': slug})
-kalshi = client.surf('GET', 'prediction-market/kalshi/markets', {'event_ticker': ticker})
+poly = surf.get('prediction-market/polymarket/markets', {'market_slug': slug})
+kalshi = surf.get('prediction-market/kalshi/markets', {'event_ticker': ticker})
 ```
 
 Compare odds across two venues, surface arb opportunities.

--- a/docs/api-reference/virtual-portrait.md
+++ b/docs/api-reference/virtual-portrait.md
@@ -1,11 +1,11 @@
 ---
 title: Virtual Portrait Enrollment
-description: Enroll an AI-generated character (no KYC, no liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0-fast videos — $0.011 USDC.
+description: Enroll an AI-generated character (no KYC, no liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0 Fast / 2.0 Mini videos — $0.011 USDC.
 ---
 
 # Virtual Portrait Enrollment
 
-Enroll an AI-generated character image as a Virtual Portrait and get back a `ta_xxxxxxxx` id you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0-fast call. Use this when you want **the same character across multiple videos** without dealing with KYC.
+Enroll an AI-generated character image as a Virtual Portrait and get back a `ta_xxxxxxxx` id you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0 Fast / 2.0 Mini call. Use this when you want **the same character across multiple videos** without dealing with KYC.
 
 :::note{title="No KYC required"}
 Use this for AI-generated personas, mascots, avatars, virtual spokespeople — no liveness step needed because the asset is understood to be a synthetic character. For **real-person likeness**, use [RealFace](realface.md) (also no KYC, but requires a brief liveness check on the rights-holder's phone to prove consent).
@@ -17,7 +17,7 @@ Use this for AI-generated personas, mascots, avatars, virtual spokespeople — n
 | **Price** | **$0.011 USDC** per enrollment (one-time, settled to BlockRun's Base wallet via x402) |
 | **Auth** | x402 micropayment header — no API key needed |
 | **Network** | Base (USDC, EIP-3009 `exact`) |
-| **Returns** | `ta_xxxxxxxx…` asset id for use with `real_face_asset_id` on Seedance 2.0 / 2.0-fast |
+| **Returns** | `ta_xxxxxxxx…` asset id for use with `real_face_asset_id` on Seedance 2.0 / 2.0 Fast / 2.0 Mini |
 
 You can use the web UI at [blockrun.ai/studio/portrait](https://blockrun.ai/studio/portrait) — wallet connect, paste an image URL, sign once, copy the `ta_xxx`. The endpoint below is for SDK / programmatic use.
 
@@ -72,7 +72,7 @@ If you're using `clawrouter` locally, this flow is fully automatic — just call
   "mirrored": true,
   "created_at": "2026-05-22T14:32:11.000Z",
   "usage": {
-    "compatible_models": ["bytedance/seedance-2.0", "bytedance/seedance-2.0-fast"],
+    "compatible_models": ["bytedance/seedance-2.0", "bytedance/seedance-2.0-fast", "bytedance/seedance-2.0-mini"],
     "how_to_use": "Pass \"real_face_asset_id\": \"ta_abcdef1234567890\" on a Seedance video generation request."
   },
   "price": { "amount": "0.0110", "currency": "USD" },

--- a/docs/api-reference/voice-phone.md
+++ b/docs/api-reference/voice-phone.md
@@ -279,16 +279,17 @@ Without an explicit "end the call after X" instruction, the AI tends to keep vol
 
 :::tab{label="TypeScript"}
 ```typescript
-import { LLMClient } from '@blockrun/llm';
+import { PhoneClient, VoiceClient } from '@blockrun/llm';
 
-const client = new LLMClient({ privateKey: process.env.BASE_CHAIN_WALLET_KEY });
+const phone = new PhoneClient({ privateKey: process.env.BASE_CHAIN_WALLET_KEY });
+const voice = new VoiceClient({ privateKey: process.env.BASE_CHAIN_WALLET_KEY });
 
 // 1) One-time setup: buy a number
-const number = await client.phoneBuy({ country: 'US', areaCode: '415' });
+const number = await phone.buyNumber({ country: 'US', areaCode: '415' });
 console.log('Got number:', number.phone_number);
 
 // 2) Place a call (uses the bought number automatically)
-const call = await client.voiceCall({
+const call = await voice.call({
   to: '+12133610872',
   task: 'Call Andy and ask him politely to take a break. Be friendly. Hang up after he confirms.',
   max_duration: 3,
@@ -298,7 +299,7 @@ const call = await client.voiceCall({
 let status;
 do {
   await new Promise(r => setTimeout(r, 5000));
-  status = await client.voiceCallStatus(call.call_id);
+  status = await voice.getStatus(call.call_id);
 } while (status.ended_by === 'IN_PROGRESS');
 
 console.log('Call ended:', status.summary);
@@ -307,15 +308,16 @@ console.log('Call ended:', status.summary);
 
 :::tab{label="Python"}
 ```python
-from blockrun_llm import LLMClient
+from blockrun_llm import PhoneClient, VoiceClient
 
-client = LLMClient()
+phone = PhoneClient()
+voice = VoiceClient()
 
 # One-time: buy a number
-number = client.phone_buy(country='US', areaCode='415')
+number = phone.buy_number(country='US', area_code='415')
 
 # Place a call
-call = client.voice_call(
+call = voice.call(
     to='+12133610872',
     task='Confirm the 7pm reservation for two under Vicky.',
     max_duration=2,
@@ -324,7 +326,7 @@ call = client.voice_call(
 # Poll
 import time
 while True:
-    status = client.voice_call_status(call['call_id'])
+    status = voice.get_status(call['call_id'])
     if status['ended_by'] != 'IN_PROGRESS':
         break
     time.sleep(5)

--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -21,7 +21,7 @@ AgentKit provides:
 - Framework extensions (`coinbase-agentkit-langchain`, …)
 
 BlockRun adds:
-- 84 AI model access
+- 71 chat models (95 in the full catalog)
 - Pay-per-request intelligence
 - No API key management
 

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -129,7 +129,7 @@ const { text } = await generateText({
 | GOAT Provides | BlockRun Adds |
 |---------------|---------------|
 | Cross-chain execution | AI decision making |
-| Protocol integrations | 84-model access |
+| Protocol integrations | 71 chat models (95 total) |
 | Wallet management | Pay-per-request AI |
 | Transaction building | No API key hassle |
 

--- a/docs/frameworks/langchain.md
+++ b/docs/frameworks/langchain.md
@@ -212,7 +212,7 @@ def get_model_for_task(task_type: str) -> str:
 llm = BlockRunLLM(model=get_model_for_task("simple"))
 ```
 
-Or let the SDK decide: the Python SDK's `smart_chat()` (bundled Router Core V3) picks the cheapest capable model per request — see [Smart Routing](../sdks/python.md#smart-routing) — and the sidecar accepts `blockrun/auto`, `blockrun/eco` and `blockrun/premium` as model ids.
+Or let the SDK decide: the Python SDK's `smart_chat()` (bundled Router Core V3) picks the cheapest capable model per request — see [Smart Routing](../sdks/python.md#smart-routing-router-core) — and the sidecar accepts `blockrun/auto`, `blockrun/eco` and `blockrun/premium` as model ids.
 
 ## Async Support
 
@@ -254,9 +254,9 @@ export BLOCKRUN_WALLET_KEY=0x...
 Or create programmatically:
 
 ```python
-from blockrun_llm import LLMClient
+from blockrun_llm import setup_agent_wallet
 
-client = LLMClient()  # Auto-creates wallet
+client = setup_agent_wallet()  # Creates ~/.blockrun/.session if none exists
 print(f"Fund this address: {client.get_wallet_address()}")
 ```
 

--- a/docs/getting-started/agent-developers.md
+++ b/docs/getting-started/agent-developers.md
@@ -62,7 +62,7 @@ response = client.chat("openai/gpt-5.4", "Analyze this market data...")
 # Anthropic
 response = client.chat("anthropic/claude-sonnet-4.6", "Review this code...")
 
-# DeepSeek (50x cheaper)
+# DeepSeek (~20x cheaper)
 response = client.chat("deepseek/deepseek-chat", "Summarize these documents...")
 ```
 :::
@@ -76,7 +76,7 @@ response = client.chat("deepseek/deepseek-chat", "Summarize these documents...")
 | [ElizaOS](../frameworks/elizaos.md) | Released | Full plugin |
 | [AgentKit](../frameworks/agentkit.md) | Compatible | SDK integration |
 | [GOAT SDK](../frameworks/goat.md) | In Review | Planned plugin |
-| [LangChain](../frameworks/langchain.md) | Planned | Custom LLM class |
+| [LangChain](../frameworks/langchain.md) | Available | LiteLLM adapter or custom LLM class |
 
 ## Architecture
 

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -65,7 +65,7 @@ blockrun_wallet action:"setup"
 Then send USDC (SPL) on the **Solana** network (Coinbase → pick "Solana", or Phantom/Solflare/Backpack). Switch back with `blockrun_wallet action:"chain" chain:"base"`.
 
 :::info
-Music, speech, video, the Modal sandbox, DeFi data, paid RealFace, paid stock prices, and native Anthropic (`claude-*`) settle on Base only. Image generation pays on either chain.
+Music, speech, the Modal sandbox, DeFi data, paid RealFace, paid stock prices, and native Anthropic (`claude-*`) settle on Base only. Image and video generation pay on either chain.
 :::
 
 ## What You Can Do Now
@@ -134,7 +134,7 @@ Top 10 tokens by DEX volume on Base, last 24h
 Call eth_getBalance on Arbitrum for 0x...
 ```
 
-`blockrun_surf` (exchange, on-chain SQL, wallet labels, social mindshare), `blockrun_price` (Pyth-backed quotes), `blockrun_dex`, `blockrun_defi` (TVL, yields), and `blockrun_rpc` (raw JSON-RPC on 40+ chains). The `crypto-data` skill says which one to use.
+`blockrun_surf` (exchange, on-chain SQL, wallet labels, social mindshare), `blockrun_price` (Pyth-backed quotes), `blockrun_dex`, `blockrun_defi` (TVL, yields), and `blockrun_rpc` (raw JSON-RPC on 40 chains). The `crypto-data` skill says which one to use.
 
 ### Phone Calls and Sandboxed Compute
 
@@ -145,18 +145,19 @@ Run this benchmark on an H100 in a disposable sandbox
 
 `blockrun_phone` makes outbound AI voice calls and leases US/CA numbers to your wallet; `blockrun_modal` runs code in an isolated container with optional GPU.
 
-### Trading (alpha-mcp)
+### Trading (Franklin)
 
-For strategy-driven crypto trading, install the separate trading MCP:
+Trading — live signals, paper trading with hard exposure caps, Polymarket bets, and a trade-plan gate that keeps real money behind your approval — is built into the [Franklin agent](../products/franklin.md). There is no separate trading MCP to install:
 
 ```bash
-claude mcp add alpha -s user -- npx -y @blockrun/alpha@latest
+npm install -g @blockrun/franklin
+franklin setup
 ```
 
-Then:
+Then, in a Franklin session:
 
 ```
-Analyze BTC/USDC for trading signals
+what's BTC looking like today?
 ```
 
 See [Trading Overview](../products/trading/overview.md) for full details.
@@ -206,14 +207,14 @@ BlockRun ships prompt-based skills that teach Claude how to use each tool family
 | `prediction-markets`, `polymarket-trading` | Read odds, then place confirm-gated bets |
 | `phone`, `modal` | Voice calls and sandboxed compute |
 
-Full list in [Skills](../mcp/skills.md). [alpha-mcp](../products/trading/overview.md) is a separate MCP server, installed with `claude mcp add`.
+Full list in [Skills](../mcp/skills.md). [Trading](../products/trading/overview.md) is built into Franklin rather than shipped as a skill or a separate MCP server.
 
 ## Pricing
 
 - **Intelligence:** Provider cost, no platform margin on chat tokens, plus $0.001 per request (no subscriptions)
 - **Images:** $0.015-0.15 per image
 - **Free tier:** `mode:"free"` chat, DEX data, crypto/FX/commodity prices, model list, Polymarket reads — $0
-- **Trading tools:** Free (open source)
+- **Trading tools:** Built into Franklin, free and open source — you pay only for the data they buy
 
 $1 gets you approximately:
 - ~500 GPT-5.4 calls

--- a/docs/getting-started/sdk-developers.md
+++ b/docs/getting-started/sdk-developers.md
@@ -54,13 +54,14 @@ go get github.com/BlockRunAI/blockrun-llm-go
 package main
 
 import (
+    "context"
     "fmt"
     blockrun "github.com/BlockRunAI/blockrun-llm-go"
 )
 
 func main() {
-    client := blockrun.NewClient("")
-    response, _ := client.Chat("openai/gpt-5.4", "Hello!")
+    client, _ := blockrun.NewLLMClient("") // "" reads BLOCKRUN_WALLET_KEY
+    response, _ := client.Chat(context.Background(), "openai/gpt-5.4", "Hello!")
     fmt.Println(response)
 }
 ```

--- a/docs/getting-started/wallet-setup.md
+++ b/docs/getting-started/wallet-setup.md
@@ -16,7 +16,7 @@ BlockRun accepts USDC on **Base** (default) or **Solana** for payments. Your age
 | **Solana Mainnet** | — | Production | USDC (SPL) |
 
 :::info{title="MCP users: pay on Solana"}
-Switch to Solana with `blockrun_wallet action:"chain" chain:"solana"` then `blockrun_wallet action:"setup"` — no env vars or restart. See [Claude Code MCP](../mcp/blockrun-mcp.md#pay-on-solana-optional). Some tools (image, music, speech, video, paid stock prices, smart routing, native Anthropic) settle on Base only.
+Switch to Solana with `blockrun_wallet action:"chain" chain:"solana"` then `blockrun_wallet action:"setup"` — no env vars or restart. See [Claude Code MCP](../mcp/blockrun-mcp.md#pay-on-solana-optional). Some tools (music, speech, paid stock prices, smart routing, native Anthropic) settle on Base only.
 :::
 
 ## How It Works
@@ -51,10 +51,10 @@ print(client.get_wallet_address())
 
 **TypeScript SDK:**
 ```typescript
-import { LLMClient } from '@blockrun/llm';
+import { setupAgentWallet } from '@blockrun/llm';
 
-const client = new LLMClient();  // Creates wallet if none exists
-console.log(await client.getAddress());
+const client = setupAgentWallet();  // Creates ~/.blockrun/.session if none exists
+console.log(client.getWalletAddress());
 ```
 
 ### Option 2: Use Existing Private Key
@@ -154,7 +154,7 @@ View your wallet on [Basescan](https://basescan.org) by searching your address.
 | Claude Code / MCP | `~/.blockrun/.session` |
 | Python SDK | `BLOCKRUN_WALLET_KEY` env var, else `~/.blockrun/.session` (legacy `~/.blockrun/wallet.key` still read) |
 | Python SDK (Solana) | `SOLANA_WALLET_KEY` env var, else `~/.blockrun/.solana-session` |
-| TypeScript SDK | `~/.blockrun/.session` or env var |
+| TypeScript SDK | `BASE_CHAIN_WALLET_KEY` env var for `new LLMClient()`; `~/.blockrun/.session` is read by `setupAgentWallet()` |
 
 Every file is written with mode `0600`. The MCP and both SDKs share the Base file, so one funded wallet serves all of them.
 

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -5,7 +5,7 @@ description: A Model Context Protocol server that gives Claude Code 71 models, c
 
 # BlockRun MCP
 
-Give Claude Code access to 95 AI models, 80+ crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 95 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 
@@ -188,7 +188,7 @@ blockrun_wallet action:"setup"                  # shows the Solana address + fun
 Then send USDC (SPL) on the **Solana** network — from Coinbase (pick "Solana"), Phantom, Solflare, or Backpack. Switch back anytime with `blockrun_wallet action:"chain" chain:"base"`. The server keeps both wallets; switching just changes which one pays.
 
 :::info
-**Base-only** (these fall back to Base regardless of active chain): `blockrun_music`, `blockrun_speech`, `blockrun_video`, `blockrun_modal`, `blockrun_defi`, paid `blockrun_realface`, paid stock `blockrun_price`, and native Anthropic (`claude-*`) passthrough. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` pays on either chain.
+**Base-only** (these fall back to Base regardless of active chain): `blockrun_music`, `blockrun_speech`, `blockrun_modal`, `blockrun_defi`, paid `blockrun_realface`, paid stock `blockrun_price`, and native Anthropic (`claude-*`) passthrough. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` and `blockrun_video` pay on either chain.
 :::
 
 ## Available Tools
@@ -286,7 +286,7 @@ DeFi fundamentals — protocol TVL, chain TVL, yield pools (APY), token prices. 
 
 #### `blockrun_rpc`
 
-Raw JSON-RPC against 40+ blockchains through one endpoint — contract reads, balances, blocks, transactions, logs, gas estimates. No node, no API key. See [Multi-chain RPC](../api-reference/multi-chain-rpc.md).
+Raw JSON-RPC against 40 blockchains through one endpoint — contract reads, balances, blocks, transactions, logs, gas estimates. No node, no API key. See [Multi-chain RPC](../api-reference/multi-chain-rpc.md).
 
 ### Media
 

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -38,8 +38,8 @@ Every skill ships inside the [blockrun-mcp](https://github.com/BlockRunAI/blockr
 
 Install any of them the same way: `/plugin install <skill>@blockrun-mcp`, e.g. `/plugin install polymarket-trading@blockrun-mcp`. The same commands work from the shell as `claude plugin marketplace add BlockRunAI/blockrun-mcp` and `claude plugin install <skill>@blockrun-mcp`.
 
-:::info{title="Trading with alpha-mcp"}
-[alpha-mcp](../products/trading/overview.md) is a separate MCP server, not a skill: `claude mcp add alpha -s user -- npx -y @blockrun/alpha@latest`. See [Trading installation](../products/trading/installation.md).
+:::info{title="Trading"}
+[Trading](../products/trading/overview.md) — signals, paper trading, Polymarket bets, and a trade-plan gate for real money — is built into the Franklin agent rather than shipped as a skill or a separate MCP server. See [Trading installation](../products/trading/installation.md).
 :::
 
 ## What Are Skills?

--- a/docs/mcp/troubleshooting.md
+++ b/docs/mcp/troubleshooting.md
@@ -285,7 +285,7 @@ blockrun_wallet action:"setup"                  # Solana address + funding QR
 Applies instantly — no env vars, no file editing, no restart. Switch back with `chain:"base"`.
 
 :::info
-`blockrun_music`, `blockrun_speech`, `blockrun_video`, `blockrun_modal`, `blockrun_defi`, paid `blockrun_realface`, paid stock `blockrun_price`, and native Anthropic (`claude-*`) settle on Base only. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` pays on either chain.
+`blockrun_music`, `blockrun_speech`, `blockrun_modal`, `blockrun_defi`, paid `blockrun_realface`, paid stock `blockrun_price`, and native Anthropic (`claude-*`) settle on Base only. In Solana mode they return a "switch to Base" message instead of charging. `blockrun_image` and `blockrun_video` pay on either chain.
 :::
 
 ## Getting Help

--- a/docs/products/creation/music-generation.md
+++ b/docs/products/creation/music-generation.md
@@ -17,7 +17,7 @@ MiniMax always generates a ~3 minute track per call. Generation takes 1-3 minute
 
 | Model | Price | Notes |
 |-------|-------|-------|
-| minimax/music-2.5+ | $0.1575 | MiniMax flagship — supports lyrics, instrumental, and style prompts |
+| minimax/music-2.5+ | $0.1585 | MiniMax flagship — supports lyrics, instrumental, and style prompts |
 
 ## Endpoint
 
@@ -80,7 +80,7 @@ Same x402 flow as all BlockRun endpoints:
 // 402 response body
 {
   "error": "Payment Required",
-  "price": { "amount": "0.157500", "currency": "USD" },
+  "price": { "amount": "0.158500", "currency": "USD" },
   "generation_info": {
     "output_duration": "~3 minutes of audio per track",
     "generation_time": "~2 minutes to generate"
@@ -177,9 +177,9 @@ Create an instrumental ambient track for a meditation app
 
 | Model | BlockRun Price |
 |-------|----------------|
-| music-2.5+ | $0.1575/track (provider cost + 5% margin, $0.15 base) |
+| music-2.5+ | $0.1585/track (provider cost + 5% margin + $0.001 transaction fee, $0.15 base) |
 
-Prices in USD, paid in USDC on Base network. Minimum charge is $0.003/request.
+Prices in USD, paid in USDC on Base network. Minimum charge is $0.001/request ($0.002 all-in with the transaction fee).
 
 ## Wallet Requirements
 

--- a/docs/products/creation/nano-banana.md
+++ b/docs/products/creation/nano-banana.md
@@ -18,7 +18,9 @@ A funded wallet on Base — $5–10 covers roughly 50–100 images. Your private
 | Model | Price | Best For |
 |-------|-------|----------|
 | Google Nano Banana | $0.05 | Fast, affordable generation |
+| Google Nano Banana 2 | $0.09 | Mid-tier quality step above Nano Banana |
 | Google Nano Banana Pro | $0.10 | Higher quality outputs |
+| ByteDance Seedream 5.0 Pro | $0.045-0.09 | Up to 4K-class resolution, reference-image editing |
 | OpenAI GPT Image 1 | $0.02-0.04 | Native OpenAI image generation |
 | OpenAI ChatGPT Images 2.0 | $0.06-0.12 | Premium quality, text rendering, edits |
 | Zhipu CogView-4 | $0.015 | Cheapest, Chinese prompts |
@@ -26,9 +28,10 @@ A funded wallet on Base — $5–10 covers roughly 50–100 images. Your private
 
 ## Installation
 
+Image generation ships as the `blockrun_image` tool in [BlockRun MCP](../../mcp/blockrun-mcp.md) — there is no separate skill to install:
+
 ```bash
-# Install the nano-banana skill
-claude skill add nano-banana
+claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 ```
 
 Or via the BlockRun MCP which includes image generation:
@@ -80,8 +83,11 @@ Generate a 16:9 banner image of blockchain nodes
 | Model | Resolution | Price |
 |-------|------------|-------|
 | Nano Banana | 1024x1024 | $0.05 |
+| Nano Banana 2 | 1024x1024 | $0.09 |
 | Nano Banana Pro | up to 2048x2048 | $0.10 |
 | Nano Banana Pro | 4096x4096 (4K) | $0.15 |
+| Seedream 5.0 Pro | up to 2048x1024 | $0.045 |
+| Seedream 5.0 Pro | 2048x2048 and above | $0.09 |
 | GPT Image 1 | 1024x1024 | $0.02 |
 | GPT Image 1 | wide/tall | $0.04 |
 | ChatGPT Images 2.0 | 1024x1024 | $0.06 |
@@ -187,8 +193,8 @@ Generate full-length tracks with lyrics or instrumental, paid per track.
 Fund a Base wallet to start generating.
 :::
 
-:::card{title="GitHub: nano-banana-blockrun" href="https://github.com/BlockRunAI/nano-banana-blockrun" icon="Code"}
-Source for the nano-banana Claude Code skill.
+:::card{title="GitHub: nano-banana-blockrun (archived)" href="https://github.com/BlockRunAI/nano-banana-blockrun" icon="Code"}
+The original Claude Code skill repo, now archived — use `blockrun_image` in BlockRun MCP instead.
 :::
 
 ::::

--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -7,10 +7,10 @@ description: Franklin is the AI agent with a wallet — it writes code and spend
 
 **The AI agent with a wallet.** Other coding agents write code; Franklin writes code *and spends money to get the job done* — picking the best model per task, buying data, generating media, paying for search, proposing trades you approve, all autonomously from one USDC wallet.
 
-**Source:** [github.com/BlockRunAI/Franklin](https://github.com/BlockRunAI/Franklin) · [npm: @blockrun/franklin](https://www.npmjs.com/package/@blockrun/franklin) · Apache-2.0 · current release **3.42.0** (2026-08-29)
+**Source:** [github.com/BlockRunAI/Franklin](https://github.com/BlockRunAI/Franklin) · [npm: @blockrun/franklin](https://www.npmjs.com/package/@blockrun/franklin) · Apache-2.0 · current release **3.42.2** (2026-08-29)
 
 :::tip{title="YOPO — You Only Pay Outcome"}
-Not a subscription (pay for access), not generic pay-per-call (pay for trying). You set an outcome and a budget; Franklin decides what to call, what to pay for, and when to stop. Provider cost + 5%, settled per action in USDC — no monthly fees, no rate limits, and no overdraft: when the wallet is empty, Franklin stops.
+Not a subscription (pay for access), not generic pay-per-call (pay for trying). You set an outcome and a budget; Franklin decides what to call, what to pay for, and when to stop. Provider rates plus a flat $0.001 per request (no margin on chat tokens; media generation and Live Search carry 5%), settled per action in USDC — no monthly fees, no rate limits, and no overdraft: when the wallet is empty, Franklin stops.
 :::
 
 ## Quick start
@@ -27,7 +27,7 @@ franklin --version
 :::
 
 :::step{title="Run — free out of the box"}
-Franklin starts on the free tier (10 reasoning, coding, and vision models), no wallet needed.
+Franklin starts on the free tier (5 reasoning, coding, and vision models), no wallet needed.
 
 ```bash
 franklin
@@ -58,7 +58,7 @@ Franklin is chat-first: you state an outcome, and it decides what to read, searc
 |---|---|
 | Code & files | `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`, `Task` (sub-agents), detached background tasks (`franklin task`) |
 | Research | `WebSearch`, `WebFetch`, Exa neural search / answer / read-URLs, `MemoryRecall` |
-| Trading & markets | `TradingSignal`, `TradingMarket`, paper-trading portfolio (`TradingPortfolio` / `TradingOpenPosition` / `TradingClosePosition` / `TradingHistory`), `TradePlan`, DEX quotes on Solana (Jupiter) and Base (0x), `PolymarketBet`, `PredictionMarket`, DeFi protocol / chain / yield / price lookups, `MultiChainRPC` (read-only, 40+ chains), `Wallet` — see [Trading](trading/overview.md) |
+| Trading & markets | `TradingSignal`, `TradingMarket`, paper-trading portfolio (`TradingPortfolio` / `TradingOpenPosition` / `TradingClosePosition` / `TradingHistory`), `TradePlan`, DEX quotes on Solana (Jupiter) and Base (0x), `PolymarketBet`, `PredictionMarket`, DeFi protocol / chain / yield / price lookups, `MultiChainRPC` (read-only, 40 chains), `Wallet` — see [Trading](trading/overview.md) |
 | Media | `ImageGen`, `VideoGen`, `MusicGen`, `RealFace` avatars, a content library (`franklin content`) |
 | Social & comms | `SearchX`, `PostToX`, `BrowserX`, phone numbers + voice calls, webhooks |
 | Compute | GPU sandbox (`ModalCreate` / `ModalExec` / `ModalStatus` / `ModalTerminate`) |

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -61,7 +61,6 @@ Provider rates per 1M tokens. Since 2026-08-07 these are also the BILLED rates â
 | Model | Input | Output |
 |-------|-------|--------|
 | Kimi K3 (1M context, image + text input) | $3.00/M | $15.00/M |
-| Kimi K2.7 (256K context, image + video input) | $0.95/M | $4.00/M |
 
 ### MiniMax
 | Model | Input | Output |
@@ -80,9 +79,9 @@ Provider rates per 1M tokens. Since 2026-08-07 these are also the BILLED rates â
 | DeepSeek V4 Pro | $0.435/M | $0.87/M |
 
 ### Free tier
-7 free models with no per-token charge (you still need a funded wallet for the x402 handshake, but these calls don't draw it down).
+5 free models with no per-token charge (you still need a funded wallet for the x402 handshake, but these calls don't draw it down).
 
-*M = million tokens. Reference provider rates; the 5% BlockRun margin is applied at billing.*
+*M = million tokens. Provider rates, billed with no BlockRun margin on chat tokens; a flat $0.001 transaction fee is added per request.*
 
 See [Pricing](pricing.md) for complete list and calculator.
 
@@ -92,7 +91,7 @@ See [Pricing](pricing.md) for complete list and calculator.
 Your cost = Provider cost (no platform margin on chat tokens) + $0.001 per request
 ```
 
-The 5% covers:
+The flat $0.001 per request covers:
 - USDC settlement infrastructure
 - Smart routing and load balancing
 - Uptime and reliability
@@ -133,7 +132,7 @@ client = LLMClient()  # Uses BLOCKRUN_WALLET_KEY
 # OpenAI model
 response = client.chat("openai/gpt-5.5", "Explain quantum computing")
 
-# DeepSeek (50x cheaper)
+# DeepSeek (~36x cheaper)
 response = client.chat("deepseek/deepseek-chat", "Explain quantum computing")
 ```
 :::
@@ -142,7 +141,6 @@ response = client.chat("deepseek/deepseek-chat", "Explain quantum computing")
 ```bash
 curl https://blockrun.ai/api/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $BLOCKRUN_WALLET_KEY" \
   -d '{
     "model": "openai/gpt-5.5",
     "messages": [{"role": "user", "content": "Hello!"}]
@@ -201,7 +199,7 @@ If a model is rate-limited or down, BlockRun can route to alternatives (opt-in).
 Set spending limits per session:
 
 ```python
-client = LLMClient(session_budget=5.00)  # Max $5 per session
+client = LLMClient(max_session_cost=5.00)  # Max $5 per session
 ```
 
 ### All Providers, One Wallet

--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -1,6 +1,6 @@
 ---
 title: Intelligence Pricing
-description: BlockRun Intelligence pricing — per-token chat at provider cost with no platform margin, a full price list, image rates, and a free tier of 8 models.
+description: BlockRun Intelligence pricing — per-token chat at provider cost with no platform margin, a full price list, image rates, and a free tier of 5 models.
 ---
 
 # Intelligence Pricing
@@ -25,13 +25,13 @@ Media generation and Live Search still carry a 5% platform margin, which covers:
 | Model | Approximate Usage |
 |-------|------------------|
 | GPT-5.5 | ~200K input tokens |
-| DeepSeek V4 Flash Chat | ~5M input tokens |
+| DeepSeek V4 Flash Chat | ~7M input tokens |
 | Gemini 3.5 Flash | ~635K input tokens |
 | Image generation | ~10–65 images |
 | **Free tier** (5 models — reasoning, coding, and vision) | **Unlimited (FREE)** |
 
 :::tip{title="Start with the free tier"}
-The free tier costs $0 — 10 reasoning, coding, and vision models with no per-token charge. You still need a funded wallet for the x402 handshake, but these calls don't draw it down.
+The free tier costs $0 — 5 reasoning, coding, and vision models with no per-token charge. You still need a funded wallet for the x402 handshake, but these calls don't draw it down.
 :::
 
 ## Full Price List
@@ -74,7 +74,7 @@ The free tier costs $0 — 10 reasoning, coding, and vision models with no per-t
 | Gemini 3.5 Flash | $1.50 | $9.00 |
 | Gemini 3.5 Flash Lite | $0.30 | $2.50 |
 
-Gemini Pro models double the input rate and add 50% to the output rate above 200K prompt tokens (the whole request reprices), mirroring Google's official long-context pricing — e.g. Gemini 2.5 Pro is $2.63 in · $15.75 out above the threshold. Flash tiers are flat.
+Gemini Pro models double the input rate and add 50% to the output rate above 200K prompt tokens (the whole request reprices), mirroring Google's official long-context pricing — e.g. Gemini 2.5 Pro is $2.50 in · $15.00 out above the threshold. Flash tiers are flat.
 
 ### xAI Grok
 
@@ -84,13 +84,15 @@ Gemini Pro models double the input rate and add 50% to the output rate above 200
 | Grok 4.3 | $1.50 | $4.00 | 1M |
 | Grok Build 0.1 | $1.50 | $3.00 | 256K |
 
-Grok doubles the per-token rates above 200K prompt tokens (the whole request reprices — e.g. Grok 4.5 is $5.25 in · $18.90 out above the threshold), mirroring xAI's official long-context tier. Live Search adds $0.025 per source used.
+Grok doubles the per-token rates above 200K prompt tokens (the whole request reprices — e.g. Grok 4.5 is $5.00 in · $18.00 out above the threshold), mirroring xAI's official long-context tier. Live Search adds $0.025 per source used.
 
 ### Z.AI
 
 | Model | Input (per 1M) | Output (per 1M) | Context |
 |-------|---------------|-----------------|---------|
-| GLM-5.2 (flagship) | $1.40 | $4.40 | 1M |
+| GLM-5.3 | $1.40 | $4.40 | 1M |
+| GLM-5.3 Flash | $0.15 | $0.50 | 1M |
+| GLM-5.2 | $1.40 | $4.40 | 1M |
 | GLM-5.1 | $1.40 | $4.40 | 200K |
 | GLM-5 | $1.00 | $3.20 | 200K |
 | GLM-5 Turbo | $1.20 | $4.00 | 200K |
@@ -100,7 +102,6 @@ Grok doubles the per-token rates above 200K prompt tokens (the whole request rep
 | Model | Input (per 1M) | Output (per 1M) | Context |
 |-------|---------------|-----------------|---------|
 | Kimi K3 | $3.00 | $15.00 | 1M |
-| Kimi K2.7 | $0.95 | $4.00 | 256K |
 
 ### MiniMax
 
@@ -112,7 +113,7 @@ Grok doubles the per-token rates above 200K prompt tokens (the whole request rep
 
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
-| Qwen3.7 Max | $1.48 | $4.42 |
+| Qwen3.7 Max | $1.48 | $4.43 |
 | Qwen3.7 Plus | $0.32 | $1.28 |
 | Qwen3.7 Flash | $0.03 | $0.13 |
 
@@ -123,9 +124,9 @@ Grok doubles the per-token rates above 200K prompt tokens (the whole request rep
 | DeepSeek V4 Flash Chat | $0.14 | $0.28 |
 | DeepSeek V4 Pro | $0.43 | $0.87 |
 
-### Free Tier (8 models)
+### Free Tier (5 models)
 
-The free tier is 10 reasoning, coding, and vision models with no per-token
+The free tier is 5 reasoning, coding, and vision models with no per-token
 charge. The lineup is kept current by a self-healing health gate that routes
 around any model whose upstream is temporarily unavailable and auto-recovers
 it, so existing calls keep working. All free-tier models are `FREE` for both
@@ -140,8 +141,11 @@ input and output — call `GET /api/v1/models` for the current live list.
 | ChatGPT Images 2.0 (1024x1024) | $0.06 |
 | ChatGPT Images 2.0 (wide/tall) | $0.12 |
 | Nano Banana | $0.05 |
+| Nano Banana 2 | $0.09 |
 | Nano Banana Pro (up to 2048²) | $0.10 |
 | Nano Banana Pro (4K) | $0.15 |
+| Seedream 5.0 Pro (up to 2048x1024) | $0.045 |
+| Seedream 5.0 Pro (2K and above) | $0.09 |
 | CogView-4 | $0.015 |
 | Grok Imagine | $0.02 |
 | Grok Imagine Pro | $0.07 |
@@ -152,12 +156,12 @@ Other media: video from **$0.05/sec**, music **$0.15/track**, text-to-speech **$
 
 | Provider | Direct Pricing | BlockRun | Difference |
 |----------|---------------|----------|------------|
-| OpenAI GPT-5.4 | $2.50/$15.00 | $2.63/$15.75 | +5% |
-| Anthropic Claude Sonnet 5 | $3.00/$15.00 | $3.15/$15.75 | +5% |
-| Anthropic Claude Sonnet 4.6 | $3.00/$15.00 | $3.15/$15.75 | +5% |
-| DeepSeek V4 Flash Chat | $0.14/$0.28 | $0.14/$0.28 | +0% |
+| OpenAI GPT-5.4 | $2.50/$15.00 | $2.50/$15.00 | 0% + $0.001/request |
+| Anthropic Claude Sonnet 5 | $3.00/$15.00 | $3.00/$15.00 | 0% + $0.001/request |
+| Anthropic Claude Sonnet 4.6 | $3.00/$15.00 | $3.00/$15.00 | 0% + $0.001/request |
+| DeepSeek V4 Flash Chat | $0.14/$0.28 | $0.14/$0.28 | 0% + $0.001/request |
 
-You pay 5% more, but you get:
+Chat is billed at the provider's list rate with no margin, plus a flat $0.001 transaction fee per request, and you get:
 - No API key management
 - No monthly invoices
 - No prepaid credits
@@ -172,7 +176,7 @@ You pay 5% more, but you get:
 from blockrun_llm import LLMClient
 
 # Limit spending per session
-client = LLMClient(session_budget=5.00)
+client = LLMClient(max_session_cost=5.00)
 ```
 
 ### Check Balance
@@ -186,9 +190,9 @@ print(f"${balance} USDC remaining")
 
 ```python
 # Get usage stats
-usage = client.get_usage()
-print(f"Spent: ${usage['total_spent']}")
-print(f"Requests: {usage['request_count']}")
+usage = client.get_spending()
+print(f"Spent: ${usage['total_usd']}")
+print(f"Requests: {usage['calls']}")
 ```
 
 ## Cost Optimization Tips
@@ -209,7 +213,7 @@ ClawRouter does all the optimization below automatically.
 # Expensive
 response = client.chat("openai/gpt-5.5", "Summarize this text")
 
-# 50x cheaper, similar quality
+# ~36x cheaper, similar quality
 response = client.chat("deepseek/deepseek-chat", "Summarize this text")
 ```
 
@@ -242,12 +246,13 @@ Shorter prompts = fewer input tokens = lower cost.
 - **No overage charges**
 - **No rate limit fees**
 
-The rates on this page are the providers' own published prices; our margin is
-added on top of them at settlement.
+The rates on this page are the providers' own published prices; chat tokens carry
+no margin — only the flat $0.001 transaction fee per request. Media generation and
+Live Search carry 5%.
 
 ## Payment Details
 
-- **Currency:** USDC on Base
+- **Currency:** USDC on Base or Solana
 - **Settlement:** Instant, on-chain
 - **Verification:** [Basescan](https://basescan.org)
 

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -10,7 +10,7 @@ description: ClawRouter is a smart LLM router for OpenClaw that picks the optima
 ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 71 models, zero API keys.
 
 :::tip{title="In a hurry?"}
-Install, fund a wallet, then run `/model blockrun/auto` in any OpenClaw conversation — that's it. Current release: **v0.12.250** (August 29, 2026).
+Install, fund a wallet, then run `/model blockrun/auto` in any OpenClaw conversation — that's it. Current release: **v0.12.253** (August 29, 2026).
 :::
 
 ## Overview
@@ -23,7 +23,7 @@ ClawRouter analyzes your prompt and automatically picks the right model tier:
 - **Math, logic, proofs** → Reasoning models (Grok 4.1 Fast Reasoning)
 - **Turns that need their tools** → Agent-tuned models (Kimi K2.7, Claude Sonnet 4.6) — selected automatically in any profile
 
-**Result:** 78% average cost savings with no quality loss.
+**Result:** 88% average cost savings on the auto profile (98% on eco) versus pinning Claude Opus 5, with no quality loss.
 
 ## Quick Start
 
@@ -232,15 +232,15 @@ Note the second row: the REASONING primary is Grok 4.1 Fast Reasoning, but the p
 
 Access all major providers through one wallet:
 
-- **OpenAI**: GPT-5.6 (Terra, Luna, Sol, and their Pro modes), GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-4.1, GPT-4o, o3, o4-mini
+- **OpenAI**: GPT-5.6 (Terra, Luna, Sol, and their Pro modes), GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-4.1, GPT-4o, o3, o4-mini
 - **Anthropic**: Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Sonnet 5, Sonnet 4.6, Haiku 4.5
 - **Google**: Gemini 3.1 Pro, Gemini 3.6 Flash, Gemini 3.5 Flash, Gemini 3.5 Flash Lite, Gemini 2.5 Pro, Gemini 2.5 Flash
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash Chat, DeepSeek Reasoner
-- **xAI**: Grok 4.5, Grok 4.3, Grok Build 0.1, Grok 4 Fast (reasoning and non-reasoning)
+- **xAI**: Grok 4.5, Grok 4.3, Grok Build 0.1
 - **Z.AI**: GLM-5.2 (flagship, 1M context), GLM-5.1, GLM-5, GLM-5 Turbo
-- **Moonshot**: Kimi K3 (flagship, 1M context), Kimi K2.7, Kimi K2.5
+- **Moonshot**: Kimi K3 (flagship, 1M context)
 - **Qwen**: Qwen3.7 Max, Qwen3.7 Plus, Qwen3.7 Flash
-- **MiniMax**: MiniMax M3, MiniMax M2.7, MiniMax M2.5
+- **MiniMax**: MiniMax M3, MiniMax M2.7
 - **Tencent / Xiaomi**: Hy3, MiMo-V2.5 Pro
 - **Free tier (all FREE)**: 5 NVIDIA-hosted chat, reasoning and vision models with no per-token charge
 
@@ -322,7 +322,7 @@ The same wallet pays for the rest of the gateway through the proxy. Prices as pu
 - **Image editing** — `/img2img --image ~/photo.png change the background to a starry sky`, with optional `--mask`.
 - **Video generation** — `/videogen a red apple slowly spinning` (`--model`, `--duration`), or `POST /v1/videos/generations`. Seedance 1.5 Pro / 2.0 Fast / 2.0 / 2.5, Sora 2, and Grok Imagine; the MP4 is downloaded to local disk so it survives the upstream's temporary bucket.
 - **Phone and voice** — `/cr-call +14155552671 "Confirm tomorrow's 3pm meeting"` places a real outbound AI voice call ($0.54 flat, up to 30 minutes); `clawrouter phone lookup|fraud|numbers ...` handles carrier lookup ($0.01), fraud signals ($0.05) and 30-day number leases ($5).
-- **Crypto data (Surf)** — `/v1/surf/*` is whitelisted through the proxy: 84 endpoints across 13 domains at $0.001 / $0.005 / $0.020 per call, including ad-hoc on-chain SQL.
+- **Crypto data (Surf)** — `/v1/surf/*` is whitelisted through the proxy: 83 endpoints at a flat $0.0085 per call including the transaction fee, including ad-hoc on-chain SQL.
 
 ## Why ClawRouter?
 
@@ -360,10 +360,10 @@ Smart routing to appropriate models:
 
 ```
 70 simple requests → DeepSeek ($0.28/M) = $0.02
-20 medium requests → Kimi K2.7 ($4.00/M) = $0.08
+20 medium requests → DeepSeek V4 Pro ($0.87/M) = $0.02
 10 complex requests → Claude Opus 5 ($25.00/M) = $0.25
 
-Total: $0.36 (saved $2.14 = 86% savings)
+Total: $0.29 (saved $2.21 = 88% savings)
 ```
 
 ## Supported Models
@@ -372,15 +372,15 @@ ClawRouter has access to all models available through BlockRun Intelligence:
 
 ### Chat Models
 
-- **OpenAI**: GPT-5.6 Terra / Luna / Sol (+ Pro), GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-4.1, GPT-4o, o1, o3, o4-mini
+- **OpenAI**: GPT-5.6 Terra / Luna / Sol (+ Pro), GPT-5.5, GPT-5.5 Pro, GPT-5.4, GPT-5.4 Pro, GPT-5.3 Codex, GPT-5.2, GPT-5.2 Pro, GPT-4.1, GPT-4o, o1, o3, o4-mini
 - **Anthropic Claude**: Fable 5, Opus 5, Opus 4.8, Sonnet 5, Sonnet 4.6, Haiku 4.5
 - **Google Gemini**: 3.1 Pro, 3.6 Flash, 3.5 Flash, 3.5 Flash Lite, 2.5 Pro, 2.5 Flash, 2.5 Flash Lite
 - **DeepSeek**: V4 Pro, V4 Flash Chat, Reasoner
-- **xAI Grok**: Grok 4.5, Grok 4.3, Grok Build 0.1, Grok 4 Fast, Grok 4.1 Fast
+- **xAI Grok**: Grok 4.5, Grok 4.3, Grok Build 0.1
 - **Z.AI**: GLM-5.2 (1M context), GLM-5.1, GLM-5, GLM-5 Turbo
-- **Moonshot**: Kimi K3 flagship (1M context), Kimi K2.7, Kimi K2.5
+- **Moonshot**: Kimi K3 flagship (1M context)
 - **Qwen**: Qwen3.7 Max, Plus, Flash
-- **MiniMax**: MiniMax M3, M2.7, M2.5
+- **MiniMax**: MiniMax M3, M2.7
 - **Tencent / Xiaomi**: Hy3, MiMo-V2.5 Pro
 - **Free tier**: 5 models, no per-token charge
 
@@ -417,7 +417,7 @@ print(result.routing.savings) # 0.94 (94% savings)
 result = client.smart_chat("Complex reasoning task...", routing_profile="premium")
 ```
 
-[Python SDK Documentation](../../sdks/python.md#smart-routing-clawrouter)
+[Python SDK Documentation](../../sdks/python.md#smart-routing-router-core)
 :::
 
 :::tab{label="TypeScript"}
@@ -439,7 +439,7 @@ const result2 = await client.smartChat('Complex reasoning task...', {
 });
 ```
 
-[TypeScript SDK Documentation](../../sdks/typescript.md#smart-routing-clawrouter)
+[TypeScript SDK Documentation](../../sdks/typescript.md#smart-routing-router-core-v3)
 :::
 
 ::::
@@ -450,7 +450,6 @@ All SDKs support the same routing profiles:
 
 | Profile | Behavior | Best For |
 |---------|----------|----------|
-| `free` | Always uses free-tier models (an alias that pins the free default and walks the free cascade) | Development, testing |
 | `eco` | Maximizes cost savings — opens on the free tier | Bulk processing |
 | `auto` | Balances quality and cost (default) | Production workloads |
 | `premium` | Always uses top-tier models | Critical tasks |

--- a/docs/products/trading/overview.md
+++ b/docs/products/trading/overview.md
@@ -20,7 +20,7 @@ Earlier versions of these pages documented `alpha-mcp`, a standalone MCP server.
 - **Paper trading** — open and close simulated positions at live prices, with a persistent portfolio and trade log across sessions
 - **Prediction markets** — research odds across Polymarket, Kalshi and others (`PredictionMarket`), and place real bets on Polymarket (`PolymarketBet`)
 - **DEX routes** — read-only quotes on Solana (Jupiter) and Base (0x)
-- **DeFi & on-chain reads** — protocol TVL, chains, yields, token prices, and read-only JSON-RPC across 40+ chains
+- **DeFi & on-chain reads** — protocol TVL, chains, yields, token prices, and read-only JSON-RPC across 40 chains
 - **Risk Management** — code-level exposure caps on paper trades, a mandatory trade plan for real money, per-order bet caps, and your own veto hooks
 - **Trade Memory** — every trade journals its thesis on open and P&L on close into a journal keyed by your wallet address, recallable from any directory
 
@@ -59,7 +59,7 @@ Franklin calls `TradingSignal` and returns a signal report with a verdict. Signa
 | BlockRun gateway | FX pairs, commodities | Free |
 | BlockRun gateway | Equity prices (12 markets) | Pay-per-call |
 | BlockRun gateway | Prediction-market search, wallet profiles, smart money | Pay-per-call |
-| BlockRun gateway | Read-only JSON-RPC across 40+ chains | Pay-per-call |
+| BlockRun gateway | Read-only JSON-RPC across 40 chains | Pay-per-call |
 | Jupiter (Solana) / 0x (Base) | DEX quotes | Free (quote only) |
 | Polymarket (Polygon) | Bet execution | Your funds + fees |
 

--- a/docs/products/trading/tools.md
+++ b/docs/products/trading/tools.md
@@ -158,7 +158,7 @@ Which Base protocols grew TVL the most this month?
 
 ## MultiChainRPC
 
-Read-only JSON-RPC across 40+ chains through one gateway endpoint (no per-chain key), paid per call. EVM chains speak `eth_*`, Solana speaks `getSlot` / `getBalance` / `getTransaction`, Bitcoin-family speaks `getblockcount`. Signing and send-transaction methods are rejected.
+Read-only JSON-RPC across 40 chains through one gateway endpoint (no per-chain key), paid per call. EVM chains speak `eth_*`, Solana speaks `getSlot` / `getBalance` / `getTransaction`, Bitcoin-family speaks `getblockcount`. Signing and send-transaction methods are rejected.
 
 ```
 Did my last Base transaction land? Check the receipt.

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -7,6 +7,14 @@ description: All notable changes to BlockRun — gateway endpoints, model lineup
 
 All notable changes to BlockRun, newest first — gateway endpoints, model lineup, pricing, and SDK releases.
 
+## [2026-08-29]
+
+### Removed — OpenAI GPT-5.3
+- Delisted **`openai/gpt-5.3`** — OpenAI has deprecated it upstream. Requests that still name it are redirected to **`openai/gpt-5.2`** (same $1.75/M in · $14.00/M out), so existing callers keep working; `openai/gpt-5.3-codex` is unaffected.
+- Visible chat models are now **71** (was 72); total catalog **95** across chat, image, video, music, speech, and sound effects.
+
+---
+
 ## [2026-08-27]
 
 ### Added — Z.AI GLM-5.3 Flash, the first natively multimodal GLM-5

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -33,7 +33,6 @@ Projects, integrations, and partners building with BlockRun and x402. Every row 
 | [blockrun-litellm](https://github.com/BlockRunAI/blockrun-litellm) | LiteLLM adapter — call x402-paid models through LiteLLM as an in-process custom provider (`blockrun/<model>`) or a local OpenAI-compatible proxy. Base and Solana | `pip install blockrun-litellm` (`[proxy]`, `[solana]` extras) |
 | [lobstercash-blockrun-skill](https://github.com/BlockRunAI/lobstercash-blockrun-skill) | BlockRun skill for the [lobster.cash](https://lobster.cash) OpenClaw plugin — chat, image generation and model browsing, paid with Solana USDC from the lobster.cash smart wallet | `curl -sSL https://raw.githubusercontent.com/BlockRunAI/lobstercash-blockrun-skill/main/install.sh \| bash` |
 | [elizaos-plugin-blockrun](https://github.com/BlockRunAI/elizaos-plugin-blockrun) | ElizaOS plugin for x402 pay-per-request AI on Base | `npm install @blockrun/elizaos-plugin` |
-| [alpha-mcp](https://github.com/BlockRunAI/alpha-mcp) | AI crypto-trading MCP server — technical analysis, DEX data, sentiment, swap execution on Base, portfolio and risk tools | `claude mcp add alpha npx @blockrun/alpha` |
 
 ### SDKs
 
@@ -90,7 +89,7 @@ Projects, integrations, and partners building with BlockRun and x402. Every row 
 | **Image Generation** | `/v1/images/generations` | $0.015–0.10/image | ✅ Live |
 | **Image Editing** | `/v1/images/image2image` | Per request | ✅ Live |
 | **Video Generation** | `/v1/videos/generations` | Per second / per M tokens | ✅ Live |
-| **Music Generation** | `/v1/audio/generations` | $0.151/track | ✅ Live |
+| **Music Generation** | `/v1/audio/generations` | $0.1585/track | ✅ Live |
 | **Text-to-Speech** | `/v1/audio/speech` | $0.05–0.10/1k chars | ✅ Live |
 | **Sound Effects** | `/v1/audio/sound-effects` | $0.0535/generation | ✅ Live |
 | **Voice Calls** | `/v1/voice/call` | $0.541 flat | ✅ Live |
@@ -110,7 +109,7 @@ Projects, integrations, and partners building with BlockRun and x402. Every row 
 | **Coinbase Onramp** | `/v1/onramp/token` | Free (Base only) | ✅ Live |
 | **Modal Sandbox** | `/v1/modal/*` | $0.002–0.011 | ✅ Live |
 | **Models** | `/v1/models` | Free | ✅ Live |
-| **Pricing** | `/v1/pricing` | Free | ✅ Live |
+| **Pricing** | `/api/pricing` | Free | ✅ Live |
 | **Balance** | `/v1/balance` | Free | ✅ Live |
 
 Per-token chat carries **no platform margin** — only the flat $0.001 transaction fee. Media generation and Live Search carry 5%. See [Pricing](../products/intelligence/pricing.md) and the full [x402 endpoint catalog](../x402/endpoints.md).
@@ -129,8 +128,8 @@ Per-token chat carries **no platform margin** — only the flat $0.001 transacti
 | Continue | Released | [Native provider](https://github.com/continuedev/continue/pull/11751) — ClawRouter as a built-in LLM provider |
 | ElizaOS | Released | [elizaos-plugin-blockrun](https://github.com/BlockRunAI/elizaos-plugin-blockrun) |
 | GOAT SDK | In Review | [GitHub Issue](https://github.com/crossmint/goat) |
-| AgentKit | Planned | [Integration Guide](../frameworks/agentkit.md) |
-| LangChain | Planned | [Custom LLM Guide](../frameworks/langchain.md) |
+| AgentKit | Available | [Integration Guide](../frameworks/agentkit.md) |
+| LangChain | Available | [Custom LLM Guide](../frameworks/langchain.md) |
 
 ## Community Projects
 
@@ -197,12 +196,12 @@ BlockRun routes to these providers via x402:
 | Anthropic | Claude Fable 5, Claude Opus 5, Claude Opus 4.8, Claude Sonnet 5, Claude Sonnet 4.6, Claude Haiku 4.5 | $1.00–$10.00 / $5.00–$50.00 |
 | Google | Gemini 3.1 Pro, Gemini 3.5 Flash | $1.50–$2.00 / $9.00–$12.00 |
 | DeepSeek | DeepSeek V4 Flash Chat, DeepSeek V4 Pro, DeepSeek Reasoner | $0.14–$0.435 / $0.28–$0.87 |
-| xAI | Grok 4.5, Grok 4.3, Grok 4 Fast, Grok Code Fast 1 | $0.20–$3.00 / $0.50–$18.00 |
+| xAI | Grok 4.5, Grok 4.3, Grok Build 0.1 | $1.50–$2.50 / $3.00–$9.00 |
 | Z.AI | GLM-5.2 (1M context), GLM-5.1, GLM-5, GLM-5 Turbo | $1.00–$1.40 / $3.20–$4.40 |
-| Moonshot | Kimi K3 (1M context, image + text input), Kimi K2.7 (256K, image + video) | $0.95–$3.00 / $4.00–$15.00 |
+| Moonshot | Kimi K3 (1M context, image + text input) | $3.00 / $15.00 |
 | MiniMax | MiniMax M3 (1M context) | $0.30 / $1.20 |
 | Qwen | Qwen3.7 Max (1M context, flagship) | $1.48 / $4.43 |
-| Free tier | 10 reasoning, coding, and vision models | **Free** |
+| Free tier | 5 reasoning, coding, and vision models | **Free** |
 
 ### Image Models
 

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -75,10 +75,6 @@ Wallet-native trading agent — persona debate, Backtest → Paper → Live, an 
 Gas-free USDC micropayments for API access via Circle Gateway.
 :::
 
-:::card{title="alpha-mcp" href="https://github.com/BlockRunAI/alpha-mcp" icon="TrendingUp"}
-AI crypto-trading MCP server — technical analysis, sentiment, execution.
-:::
-
 ::::
 
 ## Curated lists

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -12,9 +12,9 @@ Frequently asked questions about BlockRun — payments, products, models, wallet
 ### What is BlockRun?
 
 BlockRun is economic infrastructure for AI agents. It provides:
-- **Trading** — AI that analyzes markets and executes trades (alpha-mcp)
+- **Trading** — Franklin's built-in trading tools: live signals, paper trading, Polymarket bets, and a trade-plan gate for real money
 - **Creation** — generate images, video, music, and speech, paid per output
-- **Intelligence** — Access to 72 chat/LLM models via x402 micropayments
+- **Intelligence** — Access to 71 chat/LLM models via x402 micropayments
 - **Routing** — ClawRouter picks the cheapest capable model locally, in under 1ms
 
 ### What makes BlockRun different?
@@ -28,19 +28,20 @@ BlockRun is economic infrastructure for AI agents. It provides:
 
 ### Is BlockRun free?
 
-- **Trading (alpha-mcp):** Free and open source
+- **Trading (Franklin):** Free and open source — you pay only for the market data and models the tools use
 - **Creation:** Pay-per-use — images $0.015–0.15, video from $0.05/sec, music $0.15/track, text-to-speech $0.05–0.10 per 1k chars
 - **Intelligence:** Provider cost with **no platform margin** on per-token chat (since 2026-08-07) — only a flat $0.001 transaction fee per request. Media generation and Live Search carry 5%.
-- **Free tier:** 10 chat/reasoning/vision models with no per-token charge
+- **Free tier:** 5 chat/reasoning/vision models with no per-token charge
 
 ## Products
 
-### What is alpha-mcp?
+### How does trading work?
 
-alpha-mcp is our trading product. It gives Claude the tools to:
-- Analyze markets (technical indicators, sentiment)
-- Execute trades (DEX swaps on Base)
-- Manage risk (hardcoded safety limits)
+Trading is built into the Franklin agent — there is no separate package to install (the earlier `alpha-mcp` server is retired). Franklin can:
+- Analyze markets (`TradingSignal`: RSI, MACD, Bollinger Bands computed locally from live data; `TradingMarket` for crypto, FX, commodities, and equities)
+- Paper-trade at live prices with a persistent portfolio and journal
+- Research prediction-market odds and place real Polymarket bets
+- Propose real-money `TradePlan`s that nothing executes until you approve
 
 It's free and open source. See [Trading Overview](../products/trading/overview.md).
 
@@ -98,19 +99,19 @@ Payments are on-chain and final, like any blockchain transaction.
 
 ### Is AI trading risky?
 
-Yes. alpha-mcp has built-in risk limits (15% max position, 50% cash reserve, 5% daily loss limit), but all trading carries risk. Only trade what you can afford to lose.
+Yes. Franklin layers hard guardrails — paper trades are capped at $400 per position and $900 total exposure, every real-money trade needs an approved `TradePlan` (approvals expire after 15 minutes), Polymarket orders are capped at $25 by default, and `--max-spend` caps a session — but all trading carries risk. Only trade what you can afford to lose.
 
 ### Can I override the risk limits?
 
-No. Risk limits are hardcoded and cannot be overridden.
+The paper-trading caps and the trade-plan gate live in code, not in a prompt, and cannot be switched off — asking Franklin to skip them does nothing. The Polymarket per-order cap is adjustable with `POLYMARKET_MAX_BET_USD`, and your own `PreSpend` hooks can veto any money-moving tool. See [Risk Management](../products/trading/risk-management.md).
 
-### What can alpha-mcp trade?
+### What can Franklin trade?
 
-Tokens on Base via 0x Protocol. Common pairs: ETH/USDC, popular tokens with liquidity.
+Paper positions at live prices across crypto, FX, commodities, and equities; real bets on Polymarket (Polygon, your own funds); and read-only DEX quotes on Solana (Jupiter) and Base (0x). Live DEX swap execution is currently paused while Franklin adds complete local transaction validation.
 
 ### Does BlockRun charge trading fees?
 
-No. alpha-mcp is free. You only pay for intelligence (sentiment analysis) and network gas.
+No. Franklin's trading tools are free and open source. You pay only for the paid data they buy from the agent wallet (equity prices, prediction-market data, on-chain RPC, web search — signals and crypto/FX/commodity prices are free), for model calls, and for Polymarket network fees.
 
 ### Is there a per-request fee?
 
@@ -130,7 +131,7 @@ Yes — a flat $0.001 transaction fee on every paid call, which covers on-chain 
 - MiniMax (MiniMax M3)
 - Qwen (Qwen3.7 Max — 1M context, Alibaba flagship)
 - xAI (Grok 4.5, Grok 4.3, Grok Build 0.1)
-- Plus a free tier of 10 reasoning, coding, and vision models
+- Plus a free tier of 5 reasoning, coding, and vision models
 
 Full list: [Models](../api-reference/models.md)
 
@@ -144,7 +145,7 @@ Yes. Use the same format as OpenAI's Chat Completions API.
 claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 ```
 
-Then run `blockrun setup` in Claude Code.
+Then call the `blockrun_wallet` tool with `action:"setup"` in Claude Code.
 
 ### What frameworks are supported?
 
@@ -190,14 +191,14 @@ We recommend a dedicated wallet with small amounts. Don't use your main holdings
 
 **Claude Code:**
 ```
-blockrun setup
+blockrun_wallet action:"setup"
 ```
 
 **Python:**
 ```python
-from blockrun_llm import LLMClient
-client = LLMClient()  # Creates wallet automatically
-print(client.get_address())
+from blockrun_llm import setup_agent_wallet
+client = setup_agent_wallet()  # Creates a wallet if none exists
+print(client.get_wallet_address())
 ```
 
 ### How much USDC do I need?
@@ -226,7 +227,7 @@ claude
 
 Run setup:
 ```
-blockrun setup
+blockrun_wallet action:"setup"
 ```
 
 ### "Insufficient balance"
@@ -256,7 +257,7 @@ Open an issue on the relevant GitHub repository:
 - Routing: [ClawRouter](https://github.com/BlockRunAI/ClawRouter)
 - Franklin agent: [Franklin](https://github.com/BlockRunAI/Franklin)
 - CLI: [blockrun-cli](https://github.com/BlockRunAI/blockrun-cli)
-- Trading: [alpha-mcp](https://github.com/BlockRunAI/alpha-mcp)
+- Trading: built into [Franklin](https://github.com/BlockRunAI/Franklin) — see [Trading](../products/trading/overview.md)
 - Python SDK: [blockrun-llm](https://github.com/blockrunai/blockrun-llm)
 - TypeScript SDK: [blockrun-llm-ts](https://github.com/blockrunai/blockrun-llm-ts)
 - Go SDK: [blockrun-llm-go](https://github.com/blockrunai/blockrun-llm-go)

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -291,8 +291,8 @@ symbols, err := client.ListSymbols(ctx, blockrun.CategoryCrypto, &blockrun.ListO
 
 ```go
 events, err := client.PM(ctx, "polymarket/events", nil)
-markets, err := client.PM(ctx, "polymarket/search", map[string]string{"q": "bitcoin"})
-result, err := client.PMQuery(ctx, "polymarket/query", map[string]any{"filter": "active", "limit": 10})
+markets, err := client.PM(ctx, "markets/search", map[string]string{"q": "bitcoin"}) // cross-venue search
+result, err := client.PMQuery(ctx, "polymarket/wallet/identities", map[string]any{"addresses": []string{"0x..."}}) // POST endpoints
 ```
 
 ### DeFi and DEX
@@ -313,7 +313,7 @@ gq, err := client.DexGaslessQuote(ctx, params)
 
 ### Multi-chain RPC
 
-`RPCClient` wraps `POST /v1/rpc/{network}` — JSON-RPC 2.0 to every [supported chain](../api-reference/multi-chain-rpc.md) through one endpoint, $0.002 per call (a batch charges per element).
+`RPCClient` wraps `POST /v1/rpc/{network}` — JSON-RPC 2.0 to every [supported chain](../api-reference/multi-chain-rpc.md) through one endpoint, $0.003 per call including the $0.001 transaction fee (a batch charges per element).
 
 ```go
 rpcClient, err := blockrun.NewRPCClient("")

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -313,7 +313,7 @@ from blockrun_llm import (
 
 ### Every client routes
 
-`LLMClient`, `AsyncLLMClient`, `SolanaLLMClient` and `AsyncSolanaLLMClient` all expose `route()`, `smart_chat()` and `smart_chat_completion()`. Both chains run the same engine over the same catalog, so the same request picks the same model; only the x402 minimum in the cost estimate differs ($0.002 on Base, $0.001 on Solana).
+`LLMClient`, `AsyncLLMClient`, `SolanaLLMClient` and `AsyncSolanaLLMClient` all expose `route()`, `smart_chat()` and `smart_chat_completion()`. Both chains run the same engine over the same catalog, so the same request picks the same model, and the x402 minimum in the cost estimate is the same $0.001 on both chains.
 
 ```python
 import asyncio
@@ -387,7 +387,7 @@ res = img.edit("Place this logo on the t-shirt", image=["data:image/png;base64,.
 print(res.data[0].url)
 ```
 
-Models: `google/nano-banana`, `google/nano-banana-pro`, `openai/gpt-image-1`, `openai/gpt-image-2`, `zai/cogview-4`, `xai/grok-imagine-image(-pro)`.
+Models: `google/nano-banana`, `google/nano-banana-2` ($0.09), `google/nano-banana-pro`, `bytedance/seedream-5-pro` ($0.045–0.09 by resolution), `openai/gpt-image-1`, `openai/gpt-image-2`, `zai/cogview-4`, `xai/grok-imagine-image(-pro)`.
 
 #### `VideoClient`
 
@@ -420,7 +420,7 @@ from blockrun_llm import MusicClient
 
 music = MusicClient()
 res = music.generate("upbeat synthwave, driving bassline", model="minimax/music-2.5+", instrumental=True)
-print(res.data[0].url)   # URL expires ~24h; download promptly. ~$0.1575/track
+print(res.data[0].url)   # URL expires ~24h; download promptly. ~$0.1585/track
 # For vocals: instrumental=False with lyrics="..." (passing both instrumental=True and lyrics raises ValueError)
 ```
 
@@ -439,7 +439,7 @@ sfx = tts.sound_effect("rain on a tin roof", duration_seconds=6.0)
 voices = tts.list_voices()  # free, 60 req/min/IP
 ```
 
-Voices: `sarah`, `george`, `laura`, `charlie`, `river`, `roger`, `callum`, `harry`, or a raw ElevenLabs `voice_id`. Formats: `mp3` (default), `opus`, `pcm`, `wav`. Speed `0.7`–`1.2`. Billed per character (`chars/1000 × rate`, $0.003 floor) — flash/turbo cap 40k chars, multilingual-v2 10k, v3 5k.
+Voices: `sarah`, `george`, `laura`, `charlie`, `river`, `roger`, `callum`, `harry`, or a raw ElevenLabs `voice_id`. Formats: `mp3` (default), `opus`, `pcm`, `wav`. Speed `0.7`–`1.2`. Billed per character (`chars/1000 × rate`, $0.001 floor — $0.002 all-in with the transaction fee) — flash/turbo cap 40k chars, multilingual-v2 10k, v3 5k.
 
 ### Data & infrastructure
 
@@ -690,7 +690,7 @@ cluster = client.pm_wallet_cluster("0xabc...")
 | Limitless | Markets, Orderbooks |
 | Opinion | Markets, Orderbooks |
 | Predict.Fun | Markets, Orderbooks |
-| Matching | Cross-platform market matching, exact-match pairs, unified search |
+| Matching | Unified `markets/search` across venues (the market-matching and pairs endpoints were sunset upstream) |
 
 ### Async Usage
 

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -800,7 +800,7 @@ export async function POST(request: NextRequest) {
 ```typescript
 import { getCostSummary } from '@blockrun/llm';
 
-// Every paid call is appended to ~/.blockrun/data/costs.jsonl
+// Every paid call is appended to ~/.blockrun/cost_log.jsonl
 const summary = getCostSummary();
 console.log(`Lifetime: $${summary.totalUsd.toFixed(2)} over ${summary.calls} calls`);
 console.log(summary.byModel);

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -394,7 +394,7 @@ The XRPL gateway mirrored the main BlockRun catalog (last catalog sync in the ga
 
 | Provider | Models |
 |----------|--------|
-| **OpenAI** | gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-pro, gpt-5.3, gpt-5.2, gpt-5.4-mini, gpt-5-mini, gpt-5.4-nano, o1, o3, o3-mini |
+| **OpenAI** | gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-pro, gpt-5.2, gpt-5.4-mini, gpt-5-mini, gpt-5.4-nano, o1, o3, o3-mini |
 | **Anthropic** | claude-fable-5, claude-opus-5, claude-opus-4.8, claude-opus-4.7, claude-sonnet-5, claude-sonnet-4.6, claude-haiku-4.5 |
 | **Google** | gemini-3.1-pro, gemini-3-flash-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite |
 | **xAI** | grok-4.3, grok-4.5, grok-build-0.1 |
@@ -433,7 +433,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 64 models with live pricing to pick the right one for each call.
+Browse all 71 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -59,8 +59,8 @@ OpenAI-compatible. 71 models across chat, reasoning, coding, and vision — plus
 | GET  | `/api/v1/videos/generations/{id}` | Async video poll (settlement happens here on completion) | Free |
 | POST | `/api/v1/videos` | Standard multimodal `content[]` body — delegates to `/videos/generations` | Per second / token-metered |
 | GET  | `/api/v1/videos/{id}` | Poll a job created via `/api/v1/videos` | Free |
-| POST | `/api/v1/audio/speech` | Text-to-speech (ElevenLabs voices) | $0.05–$0.10 / 1k chars |
-| POST | `/api/v1/audio/generations` | Music generation (MiniMax Music) | $0.151 / track |
+| POST | `/api/v1/audio/speech` | Text-to-speech (ElevenLabs voices; `bytedance/seed-audio-1.0` at $0.003 / second) | $0.05–$0.10 / 1k chars |
+| POST | `/api/v1/audio/generations` | Music generation (MiniMax Music) | $0.1585 / track |
 | POST | `/api/v1/audio/sound-effects` | Sound-effect generation | $0.0535 / generation |
 | GET  | `/api/v1/audio/voices` | List available TTS voices | Free |
 | POST | `/api/v1/portrait/enroll` | Enroll AI character as a Virtual Portrait (`ta_xxx`) for Seedance | **$0.011 / enrollment** |
@@ -77,7 +77,7 @@ Per-model pricing is published at `/api/v1/models` and embedded in every 402 res
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| POST | `/api/v1/search` | Live search (web / news / X) | `max_results × $0.026` / source (default 10) |
+| POST | `/api/v1/search` | Live search (web / news / X) | `max_results × $0.02625` + $0.001 (default 10 sources = $0.2635) |
 | POST | `/api/v1/exa/search` | Web search | $0.011 / call |
 | POST | `/api/v1/exa/find-similar` | Find semantically similar pages | $0.011 / call |
 | POST | `/api/v1/exa/answer` | AI answer with citations | $0.011 / call |
@@ -166,13 +166,13 @@ Real-time and historical prices. All `list` endpoints are free. **Crypto, FX, an
 | GET | `/api/v1/commodity/price/{symbol}` | Commodity spot | Free |
 | GET | `/api/v1/commodity/history/{symbol}` | Commodity OHLC | Free |
 
-## Blockchain RPC (Tatum)
+## Blockchain RPC
 
 Standard JSON-RPC 2.0 to 40 chains through one endpoint — no API key. EVM (`eth_*`) and non-EVM methods. See [Multi-chain RPC](../api-reference/multi-chain-rpc.md).
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| POST | `/api/v1/rpc/{network}` | Multi-chain JSON-RPC — `ethereum`, `base`, `solana`, `polygon`, `bsc`, `arbitrum`, `bitcoin`, `xrp`, `sui`… (40+, aliases supported) | **$0.003 / call** (batch priced per element) |
+| POST | `/api/v1/rpc/{network}` | Multi-chain JSON-RPC — `ethereum`, `base`, `solana`, `polygon`, `bsc`, `arbitrum`, `bitcoin`, `xrp`, `sui`… (40, aliases supported) | **$0.003 / call** (batch priced per element) |
 | POST | `/api/v1/solana/rpc` | Solana JSON-RPC (also reachable via `/api/v1/rpc/solana`) | $0.0015 / call, batch priced per element |
 
 ## Free Endpoints


### PR DESCRIPTION
Second pass after #63 / #64, driven by three read-only audits of the docs tree against the gateway code (routes, models.ts, brand-numbers, SDK sources).

## What was wrong
- **/v1/models response shape** documented `provider`/`inputPrice`/`available` — the route returns `owned_by`, `billing_mode`, `pricing{}`. `gpt-5.3` and `glm-5-code` rows removed; `nano-banana-2` and `seedance-2.0-mini` added; image rows on one margin-inclusive convention; grok-build-0.1 is 256K.
- **RealFace / Virtual Portrait**: `seedance-2.0-mini` supports `real_face_asset_id` (matching gateway PR that fixes the enroll routes' `compatible_models`).
- **SDK snippets calling methods that do not exist**: `client.phoneBuy/voiceCall`, `client.surf(...)`, `LLMClient()` auto-creating a wallet, `get_address()`, `session_budget=`, `get_usage()`, Go `NewClient`/`Chat(model, prompt)`, TS `free` routing profile.
- **Endpoint contracts**: `/v1/search` `citations` is `string[]`; Exa responses are not wrapped in `{data}`; `/v1/responses` body amount is fee-inclusive; market-data answers `HEAD` (not `OPTIONS`); `pm/markets/search` filter is `?venue=`.
- **Pricing policy**: no chat margin since 2026-08-07 in overview / pricing / franklin / clawrouter; `$0.001` fee and `$0.002` floor; music `$0.1585`; long-context examples at list rates; free tier is 5 in nine places.
- **alpha-mcp** still sold as live in claude-code, skills, faq, ecosystem, examples → Franklin built-in trading.
- `blockrun_video` pays on either chain; Surf is 83 endpoints at a flat `$0.0085`; dead anchors in langchain / clawrouter / responses.
- Changelog: 2026-08-29 entry for the gpt-5.3 delisting (71 chat / 95 total).

Guards: `brand-numbers.docs.test.ts` + `brand-numbers.public.test.ts` green against the gateway branch that carries the 71/95 catalog (BlockRunAI/blockrun#434).