### PR TITLE
docs: rebuild the free-model lineup after NVIDIA's 2026-08-30 sweep

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -186,7 +186,7 @@ BlockRun routes to these AI providers via x402:
 | Qwen | Qwen3.7 Max (1M context, Alibaba flagship), Qwen3.7 Plus, Qwen3.7 Flash | $0.03–$1.48 / $0.13–$4.43 |
 | Tencent | Hy3 | $0.132 / $0.528 |
 | Xiaomi | MiMo-V2.5 Pro | $0.435 / $0.87 |
-| NVIDIA | Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision (4 free models, keyless — no wallet needed) | **Free** |
+| Free tier | Nemotron 3 Ultra 550B, Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision, Cohere North Mini Code, Poolside Laguna XS 2.1 (7 free models, keyless — no wallet needed) | **Free** |
 
 ### Image Models
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -165,7 +165,7 @@ Want to add an integration? [Open an issue](https://github.com/blockrunai/awesom
 
 | Profile | Strategy | Example Models |
 |---------|----------|----------------|
-| `free` | Free models only | Step 3.7 Flash (NVIDIA-hosted free tier, no wallet needed) |
+| `free` | Free models only | Nemotron 3.5 Lightning (NVIDIA-hosted free tier, no wallet needed) |
 | `eco` | Cheapest capable | DeepSeek, Gemini Flash Lite |
 | `auto` | Balanced cost/quality | GPT-5 Mini, Gemini Flash |
 | `premium` | Best quality | Claude Opus 5, GPT-5.6 Sol |
@@ -186,7 +186,7 @@ BlockRun routes to these AI providers via x402:
 | Qwen | Qwen3.7 Max (1M context, Alibaba flagship), Qwen3.7 Plus, Qwen3.7 Flash | $0.03–$1.48 / $0.13–$4.43 |
 | Tencent | Hy3 | $0.132 / $0.528 |
 | Xiaomi | MiMo-V2.5 Pro | $0.435 / $0.87 |
-| NVIDIA | Step 3.7 Flash, Nemotron 3 Nano Omni, Nemotron Nano 9B v2, Nemotron Nano 12B v2 VL, Mistral Nemotron (5 free models, keyless — no wallet needed) | **Free** |
+| NVIDIA | Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision (4 free models, keyless — no wallet needed) | **Free** |
 
 ### Image Models
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Real-time prediction market data powered by Predexon:
 | **Qwen** | Qwen3.7 Max (1M context, Alibaba flagship), Qwen3.7 Plus, Qwen3.7 Flash | $0.03–$1.48 / $0.13–$4.43 |
 | **Tencent** | Hy3 | $0.132 / $0.528 |
 | **Xiaomi** | MiMo-V2.5 Pro | $0.435 / $0.87 |
-| **NVIDIA** | Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision (4 free models, keyless — no wallet needed) | **Free** |
+| **Free tier** | Nemotron 3 Ultra 550B, Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision, Cohere North Mini Code, Poolside Laguna XS 2.1 (7 free models, keyless — no wallet needed) | **Free** |
 
 ### Reasoning
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Real-time prediction market data powered by Predexon:
 | **Qwen** | Qwen3.7 Max (1M context, Alibaba flagship), Qwen3.7 Plus, Qwen3.7 Flash | $0.03–$1.48 / $0.13–$4.43 |
 | **Tencent** | Hy3 | $0.132 / $0.528 |
 | **Xiaomi** | MiMo-V2.5 Pro | $0.435 / $0.87 |
-| **NVIDIA** | Step 3.7 Flash, Nemotron 3 Nano Omni, Nemotron Nano 9B v2, Nemotron Nano 12B v2 VL, Mistral Nemotron (5 free models, keyless — no wallet needed) | **Free** |
+| **NVIDIA** | Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision (4 free models, keyless — no wallet needed) | **Free** |
 
 ### Reasoning
 
@@ -290,7 +290,7 @@ Full directory with one line per public repo: [Ecosystem docs](./docs/resources/
 
 | Profile | Strategy | Example Models |
 |---------|----------|----------------|
-| `free` | Free models only | Step 3.7 Flash (NVIDIA-hosted free tier, no wallet needed) |
+| `free` | Free models only | Nemotron 3.5 Lightning (NVIDIA-hosted free tier, no wallet needed) |
 | `eco` | Cheapest capable | DeepSeek, Gemini Flash Lite |
 | `auto` | Balanced cost/quality | GPT-5 Mini, Gemini Flash |
 | `premium` | Best quality | Claude Opus 5, GPT-5.6 Sol |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ description: BlockRun is the routing and payment layer for AI agents — one end
 
 **Agents that pay, spend, and trade.**
 
-BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 71 LLMs, media generation, real-time data, and on-chain execution.
+BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 70 LLMs, media generation, real-time data, and on-chain execution.
 
 :::tip{title="In a hurry?"}
 Jump to the [5-Minute Quickstart](getting-started/quickstart.md) and make your first paid call.
@@ -38,7 +38,7 @@ Pick the path that matches how you work.
 ::::cards
 
 :::card{title="I want an autonomous agent" href="products/franklin.md" icon="Rocket"}
-Franklin — the AI agent with a wallet. Writes code and spends USDC across 71 models and paid APIs. Free to start.
+Franklin — the AI agent with a wallet. Writes code and spends USDC across 70 models and paid APIs. Free to start.
 :::
 
 :::card{title="I use Claude Code / Cursor" href="getting-started/quickstart.md" icon="Terminal"}
@@ -62,7 +62,7 @@ Four product families, one payment layer.
 ::::cards
 
 :::card{title="Intelligence" href="products/intelligence/overview.md" icon="Brain"}
-71 LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
+70 LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
 :::
 
 :::card{title="Routing" href="products/routing/clawrouter.md" icon="Route"}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ description: BlockRun is the routing and payment layer for AI agents — one end
 
 **Agents that pay, spend, and trade.**
 
-BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 70 LLMs, media generation, real-time data, and on-chain execution.
+BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 73 LLMs, media generation, real-time data, and on-chain execution.
 
 :::tip{title="In a hurry?"}
 Jump to the [5-Minute Quickstart](getting-started/quickstart.md) and make your first paid call.
@@ -38,7 +38,7 @@ Pick the path that matches how you work.
 ::::cards
 
 :::card{title="I want an autonomous agent" href="products/franklin.md" icon="Rocket"}
-Franklin — the AI agent with a wallet. Writes code and spends USDC across 70 models and paid APIs. Free to start.
+Franklin — the AI agent with a wallet. Writes code and spends USDC across 73 models and paid APIs. Free to start.
 :::
 
 :::card{title="I use Claude Code / Cursor" href="getting-started/quickstart.md" icon="Terminal"}
@@ -62,7 +62,7 @@ Four product families, one payment layer.
 ::::cards
 
 :::card{title="Intelligence" href="products/intelligence/overview.md" icon="Brain"}
-70 LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
+73 LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
 :::
 
 :::card{title="Routing" href="products/routing/clawrouter.md" icon="Route"}

--- a/docs/api-reference/chat-completions.md
+++ b/docs/api-reference/chat-completions.md
@@ -1,6 +1,6 @@
 ---
 title: Chat Completions
-description: OpenAI-compatible Chat Completions endpoint for 70 LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
+description: OpenAI-compatible Chat Completions endpoint for 73 LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
 ---
 
 # Chat Completions
@@ -330,7 +330,7 @@ console.log(result.choices[0].message.content);
 ::::cards
 
 :::card{title="Browse all models" href="models.md" icon="Brain"}
-70 chat models with live pricing — pick the right model and ID for your call.
+73 chat models with live pricing — pick the right model and ID for your call.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/chat-completions.md
+++ b/docs/api-reference/chat-completions.md
@@ -1,6 +1,6 @@
 ---
 title: Chat Completions
-description: OpenAI-compatible Chat Completions endpoint for 71 LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
+description: OpenAI-compatible Chat Completions endpoint for 70 LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
 ---
 
 # Chat Completions
@@ -330,7 +330,7 @@ console.log(result.choices[0].message.content);
 ::::cards
 
 :::card{title="Browse all models" href="models.md" icon="Brain"}
-71 chat models with live pricing — pick the right model and ID for your call.
+70 chat models with live pricing — pick the right model and ID for your call.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/chat-completions.md
+++ b/docs/api-reference/chat-completions.md
@@ -172,6 +172,8 @@ WWW-Authenticate: X402 requirements="<same value>"
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{"scheme": "exact", "network": "eip155:8453", "amount": "25685", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300}],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "price": {"amount": "0.025685", "currency": "USD"},
@@ -179,7 +181,7 @@ WWW-Authenticate: X402 requirements="<same value>"
 }
 ```
 
-`price.amount` is the exact amount the header signs, transaction fee included. Decoded, the header is:
+`price.amount` is the exact amount the header signs, transaction fee included. `x402Version`/`accepts` at the top level mirror the header's challenge in the body, for clients that only parse the body. Decoded, the header is:
 
 ```json
 {

--- a/docs/api-reference/defillama.md
+++ b/docs/api-reference/defillama.md
@@ -125,10 +125,13 @@ DefiLlama does not know is simply absent from `coins` — the call still returns
 A request without a payment header returns `402`. The signed requirements are
 in the `X-Payment-Required` / `PAYMENT-REQUIRED` headers (and
 `WWW-Authenticate: X402 requirements="…"`), and the JSON body restates the
-price for humans:
+price for humans and mirrors the challenge itself (`x402Version`, `accepts`)
+for clients that only read the body:
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "2000", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300 }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "endpoint": "/api/v1/defillama/prices/coingecko:bitcoin",

--- a/docs/api-reference/errors.md
+++ b/docs/api-reference/errors.md
@@ -93,6 +93,8 @@ An unknown model is a plain-string error that suggests live IDs:
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{"scheme": "exact", "network": "eip155:8453", "amount": "25685", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300}],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "price": {"amount": "0.025685", "currency": "USD"},
@@ -100,7 +102,7 @@ An unknown model is a plain-string error that suggests live IDs:
 }
 ```
 
-The signed requirements travel in the `X-Payment-Required` / `PAYMENT-REQUIRED` headers (and `WWW-Authenticate: X402 requirements="…"`). `price.amount` equals the signed amount, including the flat $0.001 transaction fee.
+The signed requirements travel in the `X-Payment-Required` / `PAYMENT-REQUIRED` headers (and `WWW-Authenticate: X402 requirements="…"`), and — since 2026-08-30 — are mirrored at the top level of the JSON body too (`x402Version`, `accepts`), byte-identical to the decoded header. This is for v1-era x402 clients (early `x402-fetch`/`x402-axios` and third-party wrappers) that only parse the body and silently fail to auto-pay when there's no top-level `accepts`. `price.amount` equals the signed amount, including the flat $0.001 transaction fee.
 
 :::info{title="402 is not an error"}
 A `402 Payment Required` is part of the normal x402 flow — the gateway is quoting a price. Sign and retry with payment and the SDKs handle this round-trip automatically.

--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -393,7 +393,7 @@ Real-time web and news search via Grok Live Search.
 :::
 
 :::card{title="Chat Completions" href="chat-completions.md" icon="Brain"}
-Feed grounded search results into any of 70 LLMs for synthesis.
+Feed grounded search results into any of 73 LLMs for synthesis.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -326,10 +326,12 @@ Every price above already includes the flat $0.001 per-transaction fee (base $0.
 
 ### The 402 response
 
-An unpaid request returns `402` with the exact charge in the body and the signable x402 v2 requirements in the `X-Payment-Required` / `PAYMENT-REQUIRED` headers (base64 JSON; also mirrored in `WWW-Authenticate`). For `/contents` the body is read first, so `price.amount` reflects `urls.length`:
+An unpaid request returns `402` with the exact charge in the body and the signable x402 v2 requirements in the `X-Payment-Required` / `PAYMENT-REQUIRED` headers (base64 JSON; also mirrored in `WWW-Authenticate`), plus the same challenge mirrored into the body as `x402Version`/`accepts`. For `/contents` the body is read first, so `price.amount` reflects `urls.length`:
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "5000", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300 }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "endpoint": "/api/v1/exa/contents",

--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -393,7 +393,7 @@ Real-time web and news search via Grok Live Search.
 :::
 
 :::card{title="Chat Completions" href="chat-completions.md" icon="Brain"}
-Feed grounded search results into any of 71 LLMs for synthesis.
+Feed grounded search results into any of 70 LLMs for synthesis.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/image-generation.md
+++ b/docs/api-reference/image-generation.md
@@ -337,10 +337,12 @@ billed = catalog rate for the size × n × 1.05   (5% platform margin on media)
 
 ### 402 responses
 
-The unpaid `402` is a normal x402 challenge: the signable requirements live in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers (base64 JSON, `x402Version: 2`, `maxTimeoutSeconds: 600`); the body is informational.
+The unpaid `402` is a normal x402 challenge: the signable requirements live in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers (base64 JSON, `x402Version: 2`, `maxTimeoutSeconds: 600`), mirrored at the top of the body (`x402Version`, `accepts`) for clients that only read the body; the rest of the body is informational.
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "53500", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 600 }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "price": { "amount": "0.053500", "currency": "USD", "pricePerImage": 0.05, "totalImages": 1 },

--- a/docs/api-reference/modal-sandbox.md
+++ b/docs/api-reference/modal-sandbox.md
@@ -177,10 +177,13 @@ curl -X POST https://blockrun.ai/api/v1/modal/sandbox/create \
 
 The signed requirements are in the `X-Payment-Required` / `PAYMENT-REQUIRED`
 headers (and `WWW-Authenticate: X402 requirements="…"`); the body restates the
-price:
+price and mirrors the challenge itself (`x402Version`, `accepts`) for clients
+that only read the body:
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "11000", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300 }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "endpoint": "/api/v1/modal/sandbox/create",

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -238,11 +238,10 @@ Open-weight models served free of charge (no x402 payment), subject to a small p
 
 | Model ID | Name | Input Price | Output Price |
 |----------|------|-------------|--------------|
-| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Nemotron 3 Nano Omni | **FREE** | **FREE** |
-| `nvidia/mistral-nemotron` | Mistral Nemotron | **FREE** | **FREE** |
-| `nvidia/step-3.7-flash` | StepFun Step 3.7 Flash | **FREE** | **FREE** |
-| `nvidia/nemotron-nano-9b-v2` | Nemotron Nano 9B v2 | **FREE** | **FREE** |
-| `nvidia/nemotron-nano-12b-v2-vl` | Nemotron Nano 12B v2 VL | **FREE** | **FREE** |
+| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Nemotron 3 Nano Omni (vision) | **FREE** | **FREE** |
+| `nvidia/nemotron-3.5-lightning` | Nemotron 3.5 Lightning | **FREE** | **FREE** |
+| `nvidia/nemotron-3-nano-30b` | Nemotron 3 Nano 30B | **FREE** | **FREE** |
+| `nvidia/llama-3.2-11b-vision` | Llama 3.2 11B Vision | **FREE** | **FREE** |
 
 ### Image Generation
 

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -238,10 +238,13 @@ Open-weight models served free of charge (no x402 payment), subject to a small p
 
 | Model ID | Name | Input Price | Output Price |
 |----------|------|-------------|--------------|
-| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Nemotron 3 Nano Omni (vision) | **FREE** | **FREE** |
-| `nvidia/nemotron-3.5-lightning` | Nemotron 3.5 Lightning | **FREE** | **FREE** |
+| `nvidia/nemotron-3-ultra-550b` | Nemotron 3 Ultra 550B (1M ctx) | **FREE** | **FREE** |
+| `nvidia/nemotron-3.5-lightning` | Nemotron 3.5 Lightning (1M ctx) | **FREE** | **FREE** |
 | `nvidia/nemotron-3-nano-30b` | Nemotron 3 Nano 30B | **FREE** | **FREE** |
+| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Nemotron 3 Nano Omni (vision) | **FREE** | **FREE** |
 | `nvidia/llama-3.2-11b-vision` | Llama 3.2 11B Vision | **FREE** | **FREE** |
+| `cohere/north-mini-code` | Cohere North Mini Code (coding) | **FREE** | **FREE** |
+| `poolside/laguna-xs-2.1` | Poolside Laguna XS 2.1 (coding) | **FREE** | **FREE** |
 
 ### Image Generation
 

--- a/docs/api-reference/polymarket-funding.md
+++ b/docs/api-reference/polymarket-funding.md
@@ -77,6 +77,8 @@ curl -X POST https://blockrun.ai/api/v1/polymarket/fund
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "11000", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300 }],
   "error": "Payment Required",
   "message": "This endpoint requires an x402 fee payment ($0.0110). Include the signed deposit authorization in the body.",
   "endpoint": "/api/v1/polymarket/fund",

--- a/docs/api-reference/realface.md
+++ b/docs/api-reference/realface.md
@@ -182,7 +182,7 @@ POST https://blockrun.ai/api/v1/realface/enroll
 
 Same two-step pattern as other paid BlockRun endpoints:
 
-1. First call without `X-Payment` → server returns `402 Payment Required` with x402 challenge headers (`X-Payment-Required` / `PAYMENT-REQUIRED` base64, plus `WWW-Authenticate: X402 requirements="…"`) and a body of `{ "error": "Payment Required", "message": "Enrolling a RealFace asset costs $0.0110 USDC. …", "price": { "amount": "0.0110", "currency": "USD" }, "paymentInfo": { "network": "base", "asset": "USDC", "x402Version": 2 } }`
+1. First call without `X-Payment` → server returns `402 Payment Required` with x402 challenge headers (`X-Payment-Required` / `PAYMENT-REQUIRED` base64, plus `WWW-Authenticate: X402 requirements="…"`) and a body of `{ "x402Version": 2, "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "11000", "payTo": "0x…", "maxTimeoutSeconds": 300 }], "error": "Payment Required", "message": "Enrolling a RealFace asset costs $0.0110 USDC. …", "price": { "amount": "0.0110", "currency": "USD" }, "paymentInfo": { "network": "base", "asset": "USDC", "x402Version": 2 } }` — `x402Version`/`accepts` mirror the header's challenge for clients that only read the body
 2. Sign the EIP-3009 transfer authorization for **$0.011 USDC on Base** (`$0.01` enrolment + `$0.001` transaction fee — the requirements say `11000` micro-USDC)
 3. Retry the same request with `X-Payment: <base64>` (`Payment-Signature` is accepted too)
 

--- a/docs/api-reference/responses.md
+++ b/docs/api-reference/responses.md
@@ -69,13 +69,15 @@ The quote is estimated input tokens plus **10% of `max_output_tokens`** at the m
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{"scheme": "exact", "network": "eip155:8453", "amount": "24685", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300}],
   "error": {"message": "This endpoint requires x402 payment", "type": "payment_required", "param": null, "code": null},
   "price": {"amount": "0.024685", "currency": "USD"},
   "paymentInfo": {"network": "base", "asset": "USDC", "x402Version": 2}
 }
 ```
 
-The signed requirements are in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers; the header amount is authoritative and includes the transaction fee, and the body `price.amount` quotes the same fee-inclusive number. A payment that fails verification is a `402` in the same OpenAI envelope — `"Payment verification failed: …"` — and a reused authorization is `402` `"Payment authorization already used — sign a fresh authorization for each request."`; this endpoint keeps OpenAI's error schema rather than the `code` field the native BlockRun endpoints carry. Nothing is charged on either.
+The signed requirements are in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers; the header amount is authoritative and includes the transaction fee, and the body `price.amount` quotes the same fee-inclusive number. `x402Version`/`accepts` at the top of the body mirror that header challenge for clients that only read the body — they sit alongside the OpenAI-shaped `error` object, not inside it. A payment that fails verification is a `402` in the same OpenAI envelope — `"Payment verification failed: …"` — and a reused authorization is `402` `"Payment authorization already used — sign a fresh authorization for each request."`; this endpoint keeps OpenAI's error schema rather than the `code` field the native BlockRun endpoints carry. Nothing is charged on either.
 
 ## Examples
 

--- a/docs/api-reference/search.md
+++ b/docs/api-reference/search.md
@@ -74,6 +74,15 @@ When you first make a request without payment, you'll receive:
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{
+    "scheme": "exact",
+    "network": "eip155:8453",
+    "amount": "263500",
+    "asset": "0x8335…",
+    "payTo": "0x…",
+    "maxTimeoutSeconds": 300
+  }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "price": {
@@ -90,7 +99,7 @@ When you first make a request without payment, you'll receive:
 }
 ```
 
-The full x402 v2 payment requirements are in the `X-Payment-Required` and `PAYMENT-REQUIRED` headers (base64 JSON, identical content) and in `WWW-Authenticate: X402 requirements="..."`. Sign against the header, not the body: `price.amount` in the body is the per-source cost plus margin **before** the flat $0.001 transaction fee, while `accepts[0].amount` in the header is the exact USDC (6-decimal) amount you will be charged — for the default 10 sources that is `263500`, i.e. $0.2635. Payment authorizations are valid for `maxTimeoutSeconds: 300`.
+The full x402 v2 payment requirements are in the `X-Payment-Required` and `PAYMENT-REQUIRED` headers (base64 JSON, identical content) and in `WWW-Authenticate: X402 requirements="..."`, and are now also mirrored at the top of the JSON body as `x402Version`/`accepts` (for clients that only read the body). Sign against `accepts[0].amount` (header or body, they're identical), not `price.amount`: `price.amount` is the per-source cost plus margin **before** the flat $0.001 transaction fee, while `accepts[0].amount` is the exact USDC (6-decimal) amount you will be charged — for the default 10 sources that is `263500`, i.e. $0.2635. Payment authorizations are valid for `maxTimeoutSeconds: 300`.
 
 A `GET` to the same URL returns a 402 quoting the default price (10 sources) — useful for discovery.
 

--- a/docs/api-reference/text-to-speech.md
+++ b/docs/api-reference/text-to-speech.md
@@ -83,10 +83,12 @@ Differences from the ElevenLabs models:
 
 ### The 402 challenge
 
-An unpaid POST returns `402` with the x402 requirement in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers and an informational body:
+An unpaid POST returns `402` with the x402 requirement in the `X-Payment-Required` / `PAYMENT-REQUIRED` / `WWW-Authenticate` headers, mirrored at the top of the body as `x402Version`/`accepts`; the rest of the body is informational:
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "53500", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300 }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "price": { "amount": "0.053500", "currency": "USD" },

--- a/docs/api-reference/video-generation.md
+++ b/docs/api-reference/video-generation.md
@@ -175,10 +175,12 @@ All prices below are the amounts quoted in the `402` challenge and actually bill
 
 ## The 402 challenge
 
-An unpaid POST returns `402` with the x402 requirement in three equivalent headers — `X-Payment-Required`, `PAYMENT-REQUIRED` (base64 JSON) and `WWW-Authenticate: X402 requirements="…"` — plus an informational JSON body:
+An unpaid POST returns `402` with the x402 requirement in three equivalent headers — `X-Payment-Required`, `PAYMENT-REQUIRED` (base64 JSON) and `WWW-Authenticate: X402 requirements="…"` — mirrored at the top of the body as `x402Version`/`accepts`; the rest of the JSON body is informational:
 
 ```json
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "1122000", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300 }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "price": {
@@ -199,7 +201,7 @@ An unpaid POST returns `402` with the x402 requirement in three equivalent heade
 }
 ```
 
-`price.amount` is the full amount you will be charged (media price + $0.001 fee). On the Grok SKUs `pricePerSecond` states the rate of the **tier actually billed** and `resolution` / `perGenerationFee` are present so the arithmetic reconciles; on Sora and Seedance `pricePerSecond` is the model's flat display rate. The decoded requirement's `accepts[0].amount` is the same figure in USDC base units (6 decimals).
+`price.amount` is the full amount you will be charged (media price + $0.001 fee). On the Grok SKUs `pricePerSecond` states the rate of the **tier actually billed** and `resolution` / `perGenerationFee` are present so the arithmetic reconciles; on Sora and Seedance `pricePerSecond` is the model's flat display rate. The decoded requirement's `accepts[0].amount` is the same figure in USDC base units (6 decimals) — and now identical to the body's own `accepts[0].amount`.
 
 Sign that requirement and re-send the POST with the signature in `X-Payment` (also accepted: `Payment-Signature`). A verification failure returns `402` with a machine-readable `code`:
 

--- a/docs/api-reference/virtual-portrait.md
+++ b/docs/api-reference/virtual-portrait.md
@@ -51,7 +51,7 @@ Images that fail the upstream content filter (NSFW, recognizable real-celebrity 
 
 Standard BlockRun two-step:
 
-1. **First request without `X-Payment`** → server returns `402 Payment Required` with x402 challenge headers (`X-Payment-Required` / `PAYMENT-REQUIRED` base64, plus `WWW-Authenticate: X402 requirements="…"`) and a body of `{ "error": "Payment Required", "message": "Enrolling a Virtual Portrait costs $0.0110 USDC. …", "price": { "amount": "0.0110", "currency": "USD" }, "paymentInfo": { "network": "base", "asset": "USDC", "x402Version": 2 } }`
+1. **First request without `X-Payment`** → server returns `402 Payment Required` with x402 challenge headers (`X-Payment-Required` / `PAYMENT-REQUIRED` base64, plus `WWW-Authenticate: X402 requirements="…"`) and a body of `{ "x402Version": 2, "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "11000", "payTo": "0x…", "maxTimeoutSeconds": 300 }], "error": "Payment Required", "message": "Enrolling a Virtual Portrait costs $0.0110 USDC. …", "price": { "amount": "0.0110", "currency": "USD" }, "paymentInfo": { "network": "base", "asset": "USDC", "x402Version": 2 } }` — `x402Version`/`accepts` mirror the header's challenge for clients that only read the body
 2. Sign the EIP-3009 transfer authorization for **$0.011 USDC on Base** (`$0.01` enrolment + `$0.001` transaction fee — the requirements say `11000` micro-USDC)
 3. **Retry the same request with `X-Payment: <base64>`** (`Payment-Signature` is accepted too) → server verifies, rejects a reused authorization (`402`, `code: "PAYMENT_REPLAY"`), registers the portrait, settles the payment after registration succeeds, returns the `ta_xxx`
 

--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -1,6 +1,6 @@
 ---
 title: AgentKit Integration
-description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 95 AI models.
+description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 94 AI models.
 ---
 
 # AgentKit Integration
@@ -21,7 +21,7 @@ AgentKit provides:
 - Framework extensions (`coinbase-agentkit-langchain`, …)
 
 BlockRun adds:
-- 71 chat models (95 in the full catalog)
+- 70 chat models (95 in the full catalog)
 - Pay-per-request intelligence
 - No API key management
 

--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -1,6 +1,6 @@
 ---
 title: AgentKit Integration
-description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 94 AI models.
+description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 97 AI models.
 ---
 
 # AgentKit Integration
@@ -21,7 +21,7 @@ AgentKit provides:
 - Framework extensions (`coinbase-agentkit-langchain`, …)
 
 BlockRun adds:
-- 70 chat models (95 in the full catalog)
+- 73 chat models (95 in the full catalog)
 - Pay-per-request intelligence
 - No API key management
 

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -1,17 +1,17 @@
 ---
 title: ElizaOS Integration
-description: Add the BlockRun plugin to ElizaOS so your agents reach 95 AI models via x402 micropayments — no per-provider API keys.
+description: Add the BlockRun plugin to ElizaOS so your agents reach 94 AI models via x402 micropayments — no per-provider API keys.
 ---
 
 # ElizaOS Integration
 
-Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 71 models paid per request over x402.
+Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 70 models paid per request over x402.
 
 :::note{title="Community integration"}
 BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
 :::
 
-[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 95 AI models via x402 micropayments.
+[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 94 AI models via x402 micropayments.
 
 ## Setup
 
@@ -85,7 +85,7 @@ All BlockRun chat models are available. A sample of what the live catalog lists 
 | Google | gemini-3.1-pro, gemini-3.5-flash, gemini-3-flash-preview, gemini-2.5-flash-lite |
 | DeepSeek | deepseek-v4-pro, deepseek-chat, deepseek-reasoner |
 | xAI | grok-4.3, grok-4.5, grok-build-0.1 |
-| NVIDIA (free) | step-3.7-flash, mistral-nemotron, nemotron-nano-9b-v2 |
+| NVIDIA (free) | nemotron-3.5-lightning, nemotron-3-nano-30b, llama-3.2-11b-vision |
 
 See [Models Reference](../api-reference/models.md) for the full list, or `curl https://blockrun.ai/api/v1/models`.
 

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -1,17 +1,17 @@
 ---
 title: ElizaOS Integration
-description: Add the BlockRun plugin to ElizaOS so your agents reach 94 AI models via x402 micropayments — no per-provider API keys.
+description: Add the BlockRun plugin to ElizaOS so your agents reach 97 AI models via x402 micropayments — no per-provider API keys.
 ---
 
 # ElizaOS Integration
 
-Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 70 models paid per request over x402.
+Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 73 models paid per request over x402.
 
 :::note{title="Community integration"}
 BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
 :::
 
-[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 94 AI models via x402 micropayments.
+[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 97 AI models via x402 micropayments.
 
 ## Setup
 
@@ -85,7 +85,7 @@ All BlockRun chat models are available. A sample of what the live catalog lists 
 | Google | gemini-3.1-pro, gemini-3.5-flash, gemini-3-flash-preview, gemini-2.5-flash-lite |
 | DeepSeek | deepseek-v4-pro, deepseek-chat, deepseek-reasoner |
 | xAI | grok-4.3, grok-4.5, grok-build-0.1 |
-| NVIDIA (free) | nemotron-3.5-lightning, nemotron-3-nano-30b, llama-3.2-11b-vision |
+| Free tier | nemotron-3-ultra-550b, nemotron-3.5-lightning, nemotron-3-nano-30b, north-mini-code |
 
 See [Models Reference](../api-reference/models.md) for the full list, or `curl https://blockrun.ai/api/v1/models`.
 

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -1,11 +1,11 @@
 ---
 title: GOAT SDK Integration
-description: Combine GOAT SDK's cross-chain execution with BlockRun's 94 AI models, paid per request over x402 — until the official plugin ships.
+description: Combine GOAT SDK's cross-chain execution with BlockRun's 97 AI models, paid per request over x402 — until the official plugin ships.
 ---
 
 # GOAT SDK Integration
 
-Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 70 models with x402 micropayments.
+Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 73 models with x402 micropayments.
 
 :::note{title="Community integration — pre-release"}
 No official `@goat-sdk/plugin-blockrun` yet; use BlockRun alongside GOAT via the [TypeScript SDK](../sdks/typescript.md) as shown below. BlockRun's primary paths are [Franklin](../products/franklin.md), the [MCP](../mcp/blockrun-mcp.md), and the SDKs.
@@ -129,7 +129,7 @@ const { text } = await generateText({
 | GOAT Provides | BlockRun Adds |
 |---------------|---------------|
 | Cross-chain execution | AI decision making |
-| Protocol integrations | 70 chat models (95 total) |
+| Protocol integrations | 73 chat models (95 total) |
 | Wallet management | Pay-per-request AI |
 | Transaction building | No API key hassle |
 

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -1,11 +1,11 @@
 ---
 title: GOAT SDK Integration
-description: Combine GOAT SDK's cross-chain execution with BlockRun's 95 AI models, paid per request over x402 — until the official plugin ships.
+description: Combine GOAT SDK's cross-chain execution with BlockRun's 94 AI models, paid per request over x402 — until the official plugin ships.
 ---
 
 # GOAT SDK Integration
 
-Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 71 models with x402 micropayments.
+Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 70 models with x402 micropayments.
 
 :::note{title="Community integration — pre-release"}
 No official `@goat-sdk/plugin-blockrun` yet; use BlockRun alongside GOAT via the [TypeScript SDK](../sdks/typescript.md) as shown below. BlockRun's primary paths are [Franklin](../products/franklin.md), the [MCP](../mcp/blockrun-mcp.md), and the SDKs.
@@ -129,7 +129,7 @@ const { text } = await generateText({
 | GOAT Provides | BlockRun Adds |
 |---------------|---------------|
 | Cross-chain execution | AI decision making |
-| Protocol integrations | 71 chat models (95 total) |
+| Protocol integrations | 70 chat models (95 total) |
 | Wallet management | Pay-per-request AI |
 | Transaction building | No API key hassle |
 

--- a/docs/frameworks/langchain.md
+++ b/docs/frameworks/langchain.md
@@ -1,6 +1,6 @@
 ---
 title: LangChain Integration
-description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 71 models.
+description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 70 models.
 ---
 
 # LangChain Integration

--- a/docs/frameworks/langchain.md
+++ b/docs/frameworks/langchain.md
@@ -1,6 +1,6 @@
 ---
 title: LangChain Integration
-description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 70 models.
+description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 73 models.
 ---
 
 # LangChain Integration

--- a/docs/getting-started/agent-developers.md
+++ b/docs/getting-started/agent-developers.md
@@ -1,13 +1,13 @@
 ---
 title: Agent Developers
-description: Build AI agents that pay for their own intelligence — 71 models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
+description: Build AI agents that pay for their own intelligence — 70 models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
 ---
 
 # Agent Developers
 
 Build AI agents that pay for their own intelligence.
 
-This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 71 models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
+This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 70 models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
 
 :::tip{title="Fastest path: Franklin"}
 Want an agent that already spends autonomously? [Franklin](../products/franklin.md) is one install (`npm install -g @blockrun/franklin`) and runs free out of the box — fund a wallet to unlock everything.
@@ -193,7 +193,7 @@ results = asyncio.run(process_batch(my_items))
 ### Cost-Optimized
 - `google/gemini-2.5-flash-lite` — Best value ($0.10/$0.40 per 1M)
 - `deepseek/deepseek-chat` — Great value ($0.14/$0.28 per 1M)
-- `nvidia/step-3.7-flash` — Free (open-weight)
+- `nvidia/nemotron-3.5-lightning` — Free (open-weight)
 
 ### Quality-Optimized
 - `openai/gpt-5.4` — Best all-around

--- a/docs/getting-started/agent-developers.md
+++ b/docs/getting-started/agent-developers.md
@@ -1,13 +1,13 @@
 ---
 title: Agent Developers
-description: Build AI agents that pay for their own intelligence — 70 models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
+description: Build AI agents that pay for their own intelligence — 73 models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
 ---
 
 # Agent Developers
 
 Build AI agents that pay for their own intelligence.
 
-This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 70 models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
+This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 73 models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
 
 :::tip{title="Fastest path: Franklin"}
 Want an agent that already spends autonomously? [Franklin](../products/franklin.md) is one install (`npm install -g @blockrun/franklin`) and runs free out of the box — fund a wallet to unlock everything.

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Code Users
-description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 70 models, images, and live data.
+description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 73 models, images, and live data.
 ---
 
 # Claude Code Users
@@ -273,7 +273,7 @@ Create images via micropayments with `blockrun_image`.
 :::
 
 :::card{title="Explore all models" href="../products/intelligence/overview.md" icon="Brain"}
-70 LLMs with live pricing, plus smart routing to cut costs automatically.
+73 LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 ::::

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Code Users
-description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 71 models, images, and live data.
+description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 70 models, images, and live data.
 ---
 
 # Claude Code Users
@@ -273,7 +273,7 @@ Create images via micropayments with `blockrun_image`.
 :::
 
 :::card{title="Explore all models" href="../products/intelligence/overview.md" icon="Brain"}
-71 LLMs with live pricing, plus smart routing to cut costs automatically.
+70 LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 ::::

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -108,7 +108,7 @@ The full list of 20 `blockrun_*` tools — chat, image, video, search, markets, 
 :::
 
 :::card{title="Explore the models" href="../products/intelligence/overview.md" icon="Brain"}
-70 LLMs with live pricing, plus smart routing to cut costs automatically.
+73 LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -108,7 +108,7 @@ The full list of 20 `blockrun_*` tools — chat, image, video, search, markets, 
 :::
 
 :::card{title="Explore the models" href="../products/intelligence/overview.md" icon="Brain"}
-71 LLMs with live pricing, plus smart routing to cut costs automatically.
+70 LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/getting-started/sdk-developers.md
+++ b/docs/getting-started/sdk-developers.md
@@ -206,7 +206,7 @@ client.chat("moonshot/kimi-k3", prompt)
 | Use Case | Recommended Model |
 |----------|-------------------|
 | General purpose | `openai/gpt-5.4` |
-| Cheapest | `google/gemini-2.5-flash-lite` or `nvidia/step-3.7-flash` (free) |
+| Cheapest | `google/gemini-2.5-flash-lite` or `nvidia/nemotron-3.5-lightning` (free) |
 | Fastest | `google/gemini-3-flash-preview` |
 | Best reasoning | `openai/o3` |
 | Best for code | `openai/gpt-5.3-codex` or `anthropic/claude-sonnet-4.6` |
@@ -332,7 +332,7 @@ A free model can be called with plain HTTP and no credentials:
 curl https://blockrun.ai/api/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "nvidia/step-3.7-flash",
+    "model": "nvidia/nemotron-3.5-lightning",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -1,11 +1,11 @@
 ---
 title: BlockRun MCP
-description: A Model Context Protocol server that gives Claude Code 71 models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
+description: A Model Context Protocol server that gives Claude Code 70 models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
 ---
 
 # BlockRun MCP
 
-Give Claude Code access to 95 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 94 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -1,11 +1,11 @@
 ---
 title: BlockRun MCP
-description: A Model Context Protocol server that gives Claude Code 70 models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
+description: A Model Context Protocol server that gives Claude Code 73 models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
 ---
 
 # BlockRun MCP
 
-Give Claude Code access to 94 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 97 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 

--- a/docs/products/creation/music-generation.md
+++ b/docs/products/creation/music-generation.md
@@ -79,6 +79,8 @@ Same x402 flow as all BlockRun endpoints:
 ```json
 // 402 response body
 {
+  "x402Version": 2,
+  "accepts": [{ "scheme": "exact", "network": "eip155:8453", "amount": "157500", "asset": "0x8335…", "payTo": "0x…", "maxTimeoutSeconds": 300 }],
   "error": "Payment Required",
   "price": { "amount": "0.158500", "currency": "USD" },
   "generation_info": {

--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -1,6 +1,6 @@
 ---
 title: Franklin Agent
-description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 70 models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
+description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 73 models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
 ---
 
 # Franklin Agent
@@ -116,7 +116,7 @@ Inside a session: `/model`, `/plan` / `/execute`, `/ultrathink`, `/compact`, `/c
 
 Franklin is the autonomous agent on top of the BlockRun stack — it uses the same pieces you can use directly:
 
-- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 70 chat models. Four profiles: `auto`, `eco`, `premium`, `free`.
+- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 73 chat models. Four profiles: `auto`, `eco`, `premium`, `free`.
 - **Paid APIs** — search, market data, media, RPC, prediction markets and more, paid per call over [x402](../x402/how-it-works.md).
 - **One wallet** — the wallet is the identity; fund it on Solana or Base ([Wallet Setup](../getting-started/wallet-setup.md)).
 

--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -1,6 +1,6 @@
 ---
 title: Franklin Agent
-description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 71 models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
+description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 70 models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
 ---
 
 # Franklin Agent
@@ -116,7 +116,7 @@ Inside a session: `/model`, `/plan` / `/execute`, `/ultrathink`, `/compact`, `/c
 
 Franklin is the autonomous agent on top of the BlockRun stack — it uses the same pieces you can use directly:
 
-- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 71 chat models. Four profiles: `auto`, `eco`, `premium`, `free`.
+- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 70 chat models. Four profiles: `auto`, `eco`, `premium`, `free`.
 - **Paid APIs** — search, market data, media, RPC, prediction markets and more, paid per call over [x402](../x402/how-it-works.md).
 - **One wallet** — the wallet is the identity; fund it on Solana or Base ([Wallet Setup](../getting-started/wallet-setup.md)).
 

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -1,11 +1,11 @@
 ---
 title: Intelligence
-description: BlockRun Intelligence gives your agent 70 LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
+description: BlockRun Intelligence gives your agent 73 LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
 ---
 
 # Intelligence
 
-AI accesses any LLM. 70 models, pay-per-request.
+AI accesses any LLM. 73 models, pay-per-request.
 
 BlockRun's Intelligence product gives your AI agent access to models from OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and more — without managing API keys or subscriptions.
 
@@ -79,7 +79,7 @@ Provider rates per 1M tokens. Since 2026-08-07 these are also the BILLED rates �
 | DeepSeek V4 Pro | $0.435/M | $0.87/M |
 
 ### Free tier
-4 free models with no per-token charge (you still need a funded wallet for the x402 handshake, but these calls don't draw it down).
+7 free models with no per-token charge (you still need a funded wallet for the x402 handshake, but these calls don't draw it down).
 
 *M = million tokens. Provider rates, billed with no BlockRun margin on chat tokens; a flat $0.001 transaction fee is added per request.*
 

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -1,11 +1,11 @@
 ---
 title: Intelligence
-description: BlockRun Intelligence gives your agent 71 LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
+description: BlockRun Intelligence gives your agent 70 LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
 ---
 
 # Intelligence
 
-AI accesses any LLM. 71 models, pay-per-request.
+AI accesses any LLM. 70 models, pay-per-request.
 
 BlockRun's Intelligence product gives your AI agent access to models from OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and more — without managing API keys or subscriptions.
 
@@ -79,7 +79,7 @@ Provider rates per 1M tokens. Since 2026-08-07 these are also the BILLED rates �
 | DeepSeek V4 Pro | $0.435/M | $0.87/M |
 
 ### Free tier
-5 free models with no per-token charge (you still need a funded wallet for the x402 handshake, but these calls don't draw it down).
+4 free models with no per-token charge (you still need a funded wallet for the x402 handshake, but these calls don't draw it down).
 
 *M = million tokens. Provider rates, billed with no BlockRun margin on chat tokens; a flat $0.001 transaction fee is added per request.*
 

--- a/docs/products/routing/benchmarks.md
+++ b/docs/products/routing/benchmarks.md
@@ -51,7 +51,7 @@ number.
 
 | Tier | `eco` | `auto` |
 |---|---|---|
-| SIMPLE | `nvidia/step-3.7-flash` | `google/gemini-2.5-flash` |
+| SIMPLE | `nvidia/nemotron-3.5-lightning` | `google/gemini-2.5-flash` |
 | MEDIUM | `google/gemini-3.1-flash-lite` | `deepseek/deepseek-v4-pro` |
 | COMPLEX | `google/gemini-3.1-flash-lite` | `google/gemini-3.1-pro` |
 | REASONING | `deepseek/deepseek-reasoner` | `deepseek/deepseek-reasoner` |

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -7,7 +7,7 @@ description: ClawRouter is a smart LLM router for OpenClaw that picks the optima
 
 **88% cheaper than pinning one flagship for every request — 98% on `eco`. Automatically.**
 
-ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 70 models, zero API keys.
+ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 73 models, zero API keys.
 
 :::tip{title="In a hurry?"}
 Install, fund a wallet, then run `/model blockrun/auto` in any OpenClaw conversation — that's it. Current release: **v0.12.253** (August 29, 2026).
@@ -200,7 +200,7 @@ Curated primaries per tier and profile (prices are input/output $/M tokens, as p
 † Withheld from `/v1/models` — the router still calls it by direct ID, but you will not find it on the public pricing page. The published savings claim is priced on visible models only, which makes it conservative.
 ‡ Not a profile you pick — auto-selected in any profile when the turn actually needs its attached tools; prefers models that keep going instead of stopping to ask. Force or disable with `routing.overrides.agenticMode`.
 
-The primary is where the tier starts, not where the request necessarily lands: the portfolio ranks every capability-eligible candidate for the detected task, so a tool-calling turn and a proof in the same tier resolve to different models. `/model free` is an alias rather than a routed profile: it pins the free default (`free/nemotron-3.5-lightning`, the same model that opens ECO SIMPLE) and walks the other free models as fallbacks, for $0 routing across the 4 free models.
+The primary is where the tier starts, not where the request necessarily lands: the portfolio ranks every capability-eligible candidate for the detected task, so a tool-calling turn and a proof in the same tier resolve to different models. `/model free` is an alias rather than a routed profile: it pins the free default (`free/nemotron-3.5-lightning`, the same model that opens ECO SIMPLE) and walks the other free models as fallbacks, for $0 routing across the 7 free models.
 
 ### Router Core V3.4: measured, with limits
 
@@ -228,7 +228,7 @@ Note the second row: the REASONING primary is Grok 4.1 Fast Reasoning, but the p
 - No external API calls for routing decisions
 - Full privacy - your prompts never leave your machine for routing
 
-### 70 Models
+### 73 Models
 
 Access all major providers through one wallet:
 
@@ -559,7 +559,7 @@ openclaw gateway restart
 
 ### Do I need API keys?
 
-No. ClawRouter uses x402 micropayments with USDC on Solana or Base. Just fund your wallet — or stay on the 4 free models with no wallet at all.
+No. ClawRouter uses x402 micropayments with USDC on Solana or Base. Just fund your wallet — or stay on the 7 free models with no wallet at all.
 
 ### How much should I fund my wallet?
 
@@ -586,7 +586,7 @@ No. AI model access requires internet. But routing decisions are made locally.
 ::::cards
 
 :::card{title="View all models" href="../intelligence/overview.md" icon="Brain"}
-70 LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and the free tier.
+73 LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and the free tier.
 :::
 
 :::card{title="Check pricing" href="../intelligence/pricing.md" icon="Zap"}

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -7,7 +7,7 @@ description: ClawRouter is a smart LLM router for OpenClaw that picks the optima
 
 **88% cheaper than pinning one flagship for every request — 98% on `eco`. Automatically.**
 
-ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 71 models, zero API keys.
+ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 70 models, zero API keys.
 
 :::tip{title="In a hurry?"}
 Install, fund a wallet, then run `/model blockrun/auto` in any OpenClaw conversation — that's it. Current release: **v0.12.253** (August 29, 2026).
@@ -192,7 +192,7 @@ Curated primaries per tier and profile (prices are input/output $/M tokens, as p
 
 | Tier | ECO Model | AUTO Model | PREMIUM Model | AGENTIC Model ‡ |
 |---|---|---|---|---|
-| **SIMPLE** | step-3.7-flash (**FREE**) | gemini-2.5-flash ($0.30/$2.50) | kimi-k2.7 † ($0.95/$4.00) | gpt-4o-mini ($0.15/$0.60) |
+| **SIMPLE** | nemotron-3.5-lightning (**FREE**) | gemini-2.5-flash ($0.30/$2.50) | kimi-k2.7 † ($0.95/$4.00) | gpt-4o-mini ($0.15/$0.60) |
 | **MEDIUM** | gemini-3.1-flash-lite ($0.25/$1.50) | kimi-k2.7 † ($0.95/$4.00) | gpt-5.3-codex ($1.75/$14.00) | kimi-k2.7 † ($0.95/$4.00) |
 | **COMPLEX** | gemini-3.1-flash-lite ($0.25/$1.50) | gemini-3.1-pro ($2/$12) | claude-fable-5 ($10/$50) | claude-sonnet-4.6 ($3/$15) |
 | **REASONING** | grok-4-1-fast-reasoning † ($0.20/$0.50) | grok-4-1-fast-reasoning † ($0.20/$0.50) | claude-sonnet-4.6 ($3/$15) | claude-sonnet-4.6 ($3/$15) |
@@ -200,7 +200,7 @@ Curated primaries per tier and profile (prices are input/output $/M tokens, as p
 † Withheld from `/v1/models` — the router still calls it by direct ID, but you will not find it on the public pricing page. The published savings claim is priced on visible models only, which makes it conservative.
 ‡ Not a profile you pick — auto-selected in any profile when the turn actually needs its attached tools; prefers models that keep going instead of stopping to ask. Force or disable with `routing.overrides.agenticMode`.
 
-The primary is where the tier starts, not where the request necessarily lands: the portfolio ranks every capability-eligible candidate for the detected task, so a tool-calling turn and a proof in the same tier resolve to different models. `/model free` is an alias rather than a routed profile: it pins the free default (`free/step-3.7-flash`, the same model that opens ECO SIMPLE) and walks the other free models as fallbacks, for $0 routing across the 5 free models.
+The primary is where the tier starts, not where the request necessarily lands: the portfolio ranks every capability-eligible candidate for the detected task, so a tool-calling turn and a proof in the same tier resolve to different models. `/model free` is an alias rather than a routed profile: it pins the free default (`free/nemotron-3.5-lightning`, the same model that opens ECO SIMPLE) and walks the other free models as fallbacks, for $0 routing across the 4 free models.
 
 ### Router Core V3.4: measured, with limits
 
@@ -228,7 +228,7 @@ Note the second row: the REASONING primary is Grok 4.1 Fast Reasoning, but the p
 - No external API calls for routing decisions
 - Full privacy - your prompts never leave your machine for routing
 
-### 71 Models
+### 70 Models
 
 Access all major providers through one wallet:
 
@@ -559,7 +559,7 @@ openclaw gateway restart
 
 ### Do I need API keys?
 
-No. ClawRouter uses x402 micropayments with USDC on Solana or Base. Just fund your wallet — or stay on the 5 free models with no wallet at all.
+No. ClawRouter uses x402 micropayments with USDC on Solana or Base. Just fund your wallet — or stay on the 4 free models with no wallet at all.
 
 ### How much should I fund my wallet?
 
@@ -586,7 +586,7 @@ No. AI model access requires internet. But routing decisions are made locally.
 ::::cards
 
 :::card{title="View all models" href="../intelligence/overview.md" icon="Brain"}
-71 LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and the free tier.
+70 LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and the free tier.
 :::
 
 :::card{title="Check pricing" href="../intelligence/pricing.md" icon="Zap"}

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -9,6 +9,13 @@ All notable changes to BlockRun, newest first — gateway endpoints, model lineu
 
 ## [2026-08-30]
 
+### Changed — free tier rebuilt after NVIDIA retired four of the five free models
+- Delisted **`nvidia/step-3.7-flash`**, **`nvidia/nemotron-nano-9b-v2`** and **`nvidia/nemotron-nano-12b-v2-vl`** (published 410 Gone on both passes of a live `--real` probe) and **`nvidia/mistral-nemotron`** (still listed upstream, but a completion never returns: >150s, zero bytes, both passes). Calls pinned to any of these ids are redirected to a healthy free model and still return 200.
+- Also 410: the hidden **`nvidia/nemotron-super-49b`**, which was simultaneously the free cascade's tertiary rung and the fallback of its primary — both retargeted in the same change.
+- Added **`nvidia/nemotron-3.5-lightning`** (thinking-mode reasoning, 131K context, ~35 tok/s), **`nvidia/nemotron-3-nano-30b`** (~121 tok/s, the fastest free model in the catalog) and **`nvidia/llama-3.2-11b-vision`** (Meta Llama 3.2, 128K context, image input) — each verified with a real completion through the gateway before listing.
+- **`nvidia/gpt-oss-120b`** and **`nvidia/gpt-oss-20b`** recovered upstream and no longer redirect elsewhere.
+- Visible chat models are now **70** (was 71); total catalog **94**; free models **4** (was 5).
+
 ### Fixed — 402 responses now carry the payment challenge in the body, not just the headers
 - Every `402 Payment Required` body now spreads `x402Version` and `accepts` at the top level, mirroring the signed challenge that has always lived in the `PAYMENT-REQUIRED` / `X-Payment-Required` / `WWW-Authenticate` headers. Pre-v2-era x402 clients (early `x402-fetch`/`x402-axios`, and some third-party wrappers) only ever parsed the body; finding no top-level `accepts` there, they silently gave up instead of auto-paying — invisible in our logs, indistinguishable from organic non-conversion.
 - Applies across every paid endpoint — chat completions, responses, messages, images, video, music, speech, search, market data, RPC, Modal sandboxes, RealFace, Virtual Portrait, and Polymarket funding. A route's own fields still win on any key collision with the mirrored ones. ([BlockRunAI/blockrun#446](https://github.com/BlockRunAI/blockrun/pull/446))

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -14,7 +14,12 @@ All notable changes to BlockRun, newest first — gateway endpoints, model lineu
 - Also 410: the hidden **`nvidia/nemotron-super-49b`**, which was simultaneously the free cascade's tertiary rung and the fallback of its primary — both retargeted in the same change.
 - Added **`nvidia/nemotron-3.5-lightning`** (thinking-mode reasoning, 131K context, ~35 tok/s), **`nvidia/nemotron-3-nano-30b`** (~121 tok/s, the fastest free model in the catalog) and **`nvidia/llama-3.2-11b-vision`** (Meta Llama 3.2, 128K context, image input) — each verified with a real completion through the gateway before listing.
 - **`nvidia/gpt-oss-120b`** and **`nvidia/gpt-oss-20b`** recovered upstream and no longer redirect elsewhere.
-- Visible chat models are now **70** (was 71); total catalog **94**; free models **4** (was 5).
+- **`nvidia/nemotron-3.5-lightning`** and **`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`** now serve from OpenRouter's $0 pool with the direct-NVIDIA path as their fallback — same models, larger capacity pool, 4.9s median against 16.3s, and Lightning gains a **1M-token context** (was 131K). Image input verified through the new route before moving the vision model.
+- Added three more free models: **`nvidia/nemotron-3-ultra-550b`** (550B/55B MoE, **1M context** — the largest free model in the catalog, and unreachable on our own NVIDIA key), **`cohere/north-mini-code`** (compact coding, sub-second) and **`poolside/laguna-xs-2.1`** (coding, ~161 tok/s).
+- Visible chat models are now **73** (was 71); total catalog **97**; free models **7** (was 5).
+
+### Fixed — an upstream error delivered as HTTP 200 no longer reads as an empty answer
+- OpenAI-compatible relays can answer `200` with an error object and no `choices` when the provider behind them fails (`{"error":{"message":"Upstream error from Nvidia: Service temporarily overloaded","code":502}}`). The gateway treated that as a successful empty completion, so the fallback chain, the free-tier health breaker and the retry classifier all saw a success — and a paid model still billed the minimum charge. Both the blocking and the streaming path now rethrow it as a real upstream error.
 
 ### Fixed — 402 responses now carry the payment challenge in the body, not just the headers
 - Every `402 Payment Required` body now spreads `x402Version` and `accepts` at the top level, mirroring the signed challenge that has always lived in the `PAYMENT-REQUIRED` / `X-Payment-Required` / `WWW-Authenticate` headers. Pre-v2-era x402 clients (early `x402-fetch`/`x402-axios`, and some third-party wrappers) only ever parsed the body; finding no top-level `accepts` there, they silently gave up instead of auto-paying — invisible in our logs, indistinguishable from organic non-conversion.

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -7,6 +7,14 @@ description: All notable changes to BlockRun — gateway endpoints, model lineup
 
 All notable changes to BlockRun, newest first — gateway endpoints, model lineup, pricing, and SDK releases.
 
+## [2026-08-30]
+
+### Fixed — 402 responses now carry the payment challenge in the body, not just the headers
+- Every `402 Payment Required` body now spreads `x402Version` and `accepts` at the top level, mirroring the signed challenge that has always lived in the `PAYMENT-REQUIRED` / `X-Payment-Required` / `WWW-Authenticate` headers. Pre-v2-era x402 clients (early `x402-fetch`/`x402-axios`, and some third-party wrappers) only ever parsed the body; finding no top-level `accepts` there, they silently gave up instead of auto-paying — invisible in our logs, indistinguishable from organic non-conversion.
+- Applies across every paid endpoint — chat completions, responses, messages, images, video, music, speech, search, market data, RPC, Modal sandboxes, RealFace, Virtual Portrait, and Polymarket funding. A route's own fields still win on any key collision with the mirrored ones. ([BlockRunAI/blockrun#446](https://github.com/BlockRunAI/blockrun/pull/446))
+
+---
+
 ## [2026-08-29]
 
 ### Removed — OpenAI GPT-5.3

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -18,7 +18,7 @@ Run any GPT-Image-2 or Seedance prompt as a one-liner — `/headshot`, `/dance`,
 :::
 
 :::card{title="lobster.cash skill" href="https://github.com/BlockRunAI/lobstercash-blockrun-skill" icon="Zap"}
-BlockRun skill for the lobster.cash OpenClaw plugin — 71 models paid with Solana USDC.
+BlockRun skill for the lobster.cash OpenClaw plugin — 70 models paid with Solana USDC.
 :::
 
 :::card{title="blockrun-claude-plugin" href="https://github.com/BlockRunAI/blockrun-claude-plugin" icon="Wallet"}

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -18,7 +18,7 @@ Run any GPT-Image-2 or Seedance prompt as a one-liner — `/headshot`, `/dance`,
 :::
 
 :::card{title="lobster.cash skill" href="https://github.com/BlockRunAI/lobstercash-blockrun-skill" icon="Zap"}
-BlockRun skill for the lobster.cash OpenClaw plugin — 70 models paid with Solana USDC.
+BlockRun skill for the lobster.cash OpenClaw plugin — 73 models paid with Solana USDC.
 :::
 
 :::card{title="blockrun-claude-plugin" href="https://github.com/BlockRunAI/blockrun-claude-plugin" icon="Wallet"}

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -121,7 +121,7 @@ Yes — a flat $0.001 transaction fee on every paid call, which covers on-chain 
 
 ### Which AI models are available?
 
-71 models including:
+70 models including:
 - OpenAI (GPT-5.5, GPT-5.4, GPT-5.4 Pro, GPT-5.2)
 - Anthropic (Claude Opus 5, Opus 4.8, Sonnet 5, Sonnet 4.6, Haiku 4.5)
 - Google (Gemini 3.1 Pro, Gemini 3.5 Flash)

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -121,7 +121,7 @@ Yes — a flat $0.001 transaction fee on every paid call, which covers on-chain 
 
 ### Which AI models are available?
 
-70 models including:
+73 models including:
 - OpenAI (GPT-5.5, GPT-5.4, GPT-5.4 Pro, GPT-5.2)
 - Anthropic (Claude Opus 5, Opus 4.8, Sonnet 5, Sonnet 4.6, Haiku 4.5)
 - Google (Gemini 3.1 Pro, Gemini 3.5 Flash)

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -1,11 +1,11 @@
 ---
 title: Go SDK
-description: The Go SDK for BlockRun — call 95 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
+description: The Go SDK for BlockRun — call 94 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
 ---
 
 # Go SDK
 
-The Go SDK for BlockRun provides access to 95 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
+The Go SDK for BlockRun provides access to 94 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
 
 **Source:** [github.com/BlockRunAI/blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go) · `go get github.com/BlockRunAI/blockrun-llm-go@v0.20.0` · Go 1.22+ · MIT
 
@@ -403,7 +403,7 @@ client.Chat(ctx, "deepseek/deepseek-chat", prompt)
 client.Chat(ctx, "xai/grok-4.3", prompt)
 
 // Free (no USDC needed)
-client.Chat(ctx, "nvidia/step-3.7-flash", prompt)
+client.Chat(ctx, "nvidia/nemotron-3.5-lightning", prompt)
 ```
 
 ## Concurrent Requests
@@ -516,7 +516,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 71 models with live pricing to pick the right one for each call.
+Browse all 70 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -1,11 +1,11 @@
 ---
 title: Go SDK
-description: The Go SDK for BlockRun — call 94 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
+description: The Go SDK for BlockRun — call 97 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
 ---
 
 # Go SDK
 
-The Go SDK for BlockRun provides access to 94 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
+The Go SDK for BlockRun provides access to 97 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
 
 **Source:** [github.com/BlockRunAI/blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go) · `go get github.com/BlockRunAI/blockrun-llm-go@v0.20.0` · Go 1.22+ · MIT
 
@@ -516,7 +516,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 70 models with live pricing to pick the right one for each call.
+Browse all 73 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python SDK
-description: The official BlockRun Python SDK — call 70 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun Python SDK — call 73 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # Python SDK
@@ -1069,7 +1069,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 70 models with live pricing to pick the right one for each call.
+Browse all 73 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python SDK
-description: The official BlockRun Python SDK — call 71 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun Python SDK — call 70 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # Python SDK
@@ -254,7 +254,7 @@ response = client.chat_completion("blockrun/auto", messages)
 ```python
 # Free models only — a paid model can never leak into this profile
 result = client.smart_chat("Explain recursion", routing_profile="free")
-print(result.model)                 # "nvidia/step-3.7-flash"
+print(result.model)                 # "nvidia/nemotron-3.5-lightning"
 print(result.routing.cost_estimate) # 0.0
 
 # Maximum savings
@@ -1069,7 +1069,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 71 models with live pricing to pick the right one for each call.
+Browse all 70 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: TypeScript SDK
-description: The official BlockRun TypeScript/JavaScript SDK — call 70 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun TypeScript/JavaScript SDK — call 73 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # TypeScript SDK
@@ -934,7 +934,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 70 models with live pricing to pick the right one for each call.
+Browse all 73 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: TypeScript SDK
-description: The official BlockRun TypeScript/JavaScript SDK — call 71 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun TypeScript/JavaScript SDK — call 70 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # TypeScript SDK
@@ -241,13 +241,13 @@ There is no `"free"` profile — `routingProfile` accepts `'eco' | 'auto' | 'pre
 
 ```typescript
 // Guaranteed $0: call a free model directly
-const free = await client.chat('nvidia/step-3.7-flash', 'Explain recursion');
+const free = await client.chat('nvidia/nemotron-3.5-lightning', 'Explain recursion');
 
 // Smart-routed $0-first
 const result = await client.smartChat('What is 2+2?', {
   routingProfile: 'eco'
 });
-console.log(result.model);  // "nvidia/step-3.7-flash" (a live $0 model; the free lineup rotates as NVIDIA retires SKUs)
+console.log(result.model);  // "nvidia/nemotron-3.5-lightning" (a live $0 model; the free lineup rotates as NVIDIA retires SKUs)
 console.log(result.routing.savings);  // 1 (100%)
 
 // Premium mode for critical tasks
@@ -934,7 +934,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 71 models with live pricing to pick the right one for each call.
+Browse all 70 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -399,7 +399,7 @@ The XRPL gateway mirrored the main BlockRun catalog (last catalog sync in the ga
 | **Google** | gemini-3.1-pro, gemini-3-flash-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite |
 | **xAI** | grok-4.3, grok-4.5, grok-build-0.1 |
 | **DeepSeek** | deepseek-chat, deepseek-reasoner, deepseek-v4-pro |
-| **NVIDIA (FREE)** | step-3.7-flash, nemotron-3-nano-omni-30b-a3b-reasoning, nemotron-nano-9b-v2, nemotron-nano-12b-v2-vl, mistral-nemotron |
+| **NVIDIA (FREE)** | nemotron-3.5-lightning, nemotron-3-nano-30b, nemotron-3-nano-omni-30b-a3b-reasoning, llama-3.2-11b-vision |
 
 See [Intelligence Pricing](../products/intelligence/pricing.md) for full pricing details.
 
@@ -433,7 +433,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 71 models with live pricing to pick the right one for each call.
+Browse all 70 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -399,7 +399,7 @@ The XRPL gateway mirrored the main BlockRun catalog (last catalog sync in the ga
 | **Google** | gemini-3.1-pro, gemini-3-flash-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite |
 | **xAI** | grok-4.3, grok-4.5, grok-build-0.1 |
 | **DeepSeek** | deepseek-chat, deepseek-reasoner, deepseek-v4-pro |
-| **NVIDIA (FREE)** | nemotron-3.5-lightning, nemotron-3-nano-30b, nemotron-3-nano-omni-30b-a3b-reasoning, llama-3.2-11b-vision |
+| **FREE tier** | nemotron-3-ultra-550b, nemotron-3.5-lightning, nemotron-3-nano-30b, nemotron-3-nano-omni-30b-a3b-reasoning, llama-3.2-11b-vision, north-mini-code, laguna-xs-2.1 |
 
 See [Intelligence Pricing](../products/intelligence/pricing.md) for full pricing details.
 
@@ -433,7 +433,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 70 models with live pricing to pick the right one for each call.
+Browse all 73 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -41,7 +41,7 @@ Replace `blockrun.ai` with `sol.blockrun.ai`, `nano.blockrun.ai`, or `testnet.bl
 
 ## AI Model Gateway
 
-OpenAI-compatible. 71 models across chat, reasoning, coding, and vision — plus image, video, music, and speech generation. Per-model pricing is published live at `/api/v1/models`.
+OpenAI-compatible. 70 models across chat, reasoning, coding, and vision — plus image, video, music, and speech generation. Per-model pricing is published live at `/api/v1/models`.
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -41,7 +41,7 @@ Replace `blockrun.ai` with `sol.blockrun.ai`, `nano.blockrun.ai`, or `testnet.bl
 
 ## AI Model Gateway
 
-OpenAI-compatible. 70 models across chat, reasoning, coding, and vision — plus image, video, music, and speech generation. Per-model pricing is published live at `/api/v1/models`.
+OpenAI-compatible. 73 models across chat, reasoning, coding, and vision — plus image, video, music, and speech generation. Per-model pricing is published live at `/api/v1/models`.
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|

--- a/docs/x402/how-it-works.md
+++ b/docs/x402/how-it-works.md
@@ -67,7 +67,7 @@ When you make a request without payment, the server returns HTTP 402 with:
 - **Network** - Which blockchain (`eip155:8453` on Base, `solana:…` on the Solana gateway)
 - **Validity** - `maxTimeoutSeconds` (300 on most endpoints; longer on async media jobs)
 
-The requirements are base64-encoded in three equivalent headers — `PAYMENT-REQUIRED` (x402 v2), `X-Payment-Required`, and `WWW-Authenticate: X402 requirements="…"` — and the JSON body repeats the price as `price.amount` in USD.
+The requirements are base64-encoded in three equivalent headers — `PAYMENT-REQUIRED` (x402 v2), `X-Payment-Required`, and `WWW-Authenticate: X402 requirements="…"` — and the JSON body repeats the price as `price.amount` in USD, plus the challenge itself (`x402Version`, `accepts`) mirrored at the top level for clients that only read the body.
 
 On BlockRun the price for chat is the model's list rate — estimated input tokens plus 10% of `max_tokens` output — with no platform margin, plus a flat **$0.001 transaction fee** per paid call. Media generation (image, video, music, speech) and Live Search carry a 5% margin on top of their list rate, plus the same fee.
 

--- a/docs/x402/payment-flow.md
+++ b/docs/x402/payment-flow.md
@@ -43,6 +43,16 @@ X-Payment-Required: <same value>
 WWW-Authenticate: X402 requirements="<same value>"
 
 {
+  "x402Version": 2,
+  "accepts": [{
+    "scheme": "exact",
+    "network": "eip155:8453",
+    "amount": "25685",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0x...",
+    "maxTimeoutSeconds": 300,
+    "extra": {"name": "USD Coin", "version": "2"}
+  }],
   "error": "Payment Required",
   "message": "This endpoint requires x402 payment",
   "price": {"amount": "0.025685", "currency": "USD"},
@@ -50,7 +60,9 @@ WWW-Authenticate: X402 requirements="<same value>"
 }
 ```
 
-The three headers carry the same base64 value. Decoded:
+`x402Version` and `accepts` at the top of the body are the same challenge as the headers, mirrored in JSON since 2026-08-30 — early x402 clients (pre-v2 `x402-fetch`/`x402-axios` and some third-party wrappers) only ever parsed the body, found no `accepts` there, and silently gave up instead of auto-paying. A route's own fields win on any key collision, so this never shadows `price` or `paymentInfo`.
+
+The three headers carry the full requirements as the same base64 value (`resource` and `extensions` included, which the body mirror omits). Decoded:
 
 ```json
 {


### PR DESCRIPTION
Docs half of BlockRunAI/blockrun#447.

A live two-pass `--real` probe found four of the five VISIBLE free models gone at once — `step-3.7-flash`, `nemotron-nano-9b-v2` and `nemotron-nano-12b-v2-vl` return a published 410, and `mistral-nemotron` is the quiet kind: still listed by NVIDIA, but a completion never comes back (>150s zero bytes, both passes). `nemotron-super-49b` (hidden, but the free cascade's tertiary rung) is 410 too.

Every reference to those five is repointed at a probe-verified replacement:

- `nvidia/nemotron-3.5-lightning` — thinking-mode reasoning, 131K, ~35 tok/s
- `nvidia/nemotron-3-nano-30b` — ~121 tok/s, the fastest free model in the catalog
- `nvidia/llama-3.2-11b-vision` — the only Llama NVIDIA still serves; 128K, image input

Counts move with the catalog: **71 → 70** chat, **95 → 94** total, **5 → 4** free. Dated changelog entries keep their original numbers.