### PR TITLE
docs(pricing): the pricing table missed the DeepSeek V4 Pro reprice and both GPT-5.6 Pro corrections

### DIFF
--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -43,9 +43,9 @@ The free tier costs $0 — 5 reasoning, coding, and vision models with no per-to
 | GPT-5.6 Sol (flagship) | $5.00 | $30.00 |
 | GPT-5.6 Sol Pro | $5.00 | $30.00 |
 | GPT-5.6 Terra | $2.00 | $12.00 |
-| GPT-5.6 Terra Pro | $1.00 | $6.00 |
+| GPT-5.6 Terra Pro | $2.00 | $12.00 |
 | GPT-5.6 Luna | $0.20 | $1.20 |
-| GPT-5.6 Luna Pro | $0.10 | $0.60 |
+| GPT-5.6 Luna Pro | $0.20 | $1.20 |
 | GPT-5.5 | $5.00 | $30.00 |
 | GPT-5.5 Pro | $30.00 | $180.00 |
 | GPT-5.4 | $2.50 | $15.00 |
@@ -122,7 +122,9 @@ Grok doubles the per-token rates above 200K prompt tokens (the whole request rep
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
 | DeepSeek V4 Flash Chat | $0.14 | $0.28 |
-| DeepSeek V4 Pro | $0.43 | $0.87 |
+| DeepSeek V4 Flash Reasoner | $0.14 | $0.28 |
+| DeepSeek V4 Flash Vision (image input) | $0.44 | $1.32 |
+| DeepSeek V4 Pro | $1.32 | $3.96 |
 
 ### Free Tier (5 models)
 

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -215,7 +215,7 @@ Real decisions from Router Core's bundled defaults on `auto` (prices are output 
 | Prompt | Tier / task | Routed To | Output $/M |
 |--------|-------------|-----------|------------|
 | "What is the capital of France?" | SIMPLE / chat | google/gemini-2.5-flash | $2.50 |
-| "Prove that the sum of two odd integers is even, step by step." | REASONING / reasoning | deepseek/deepseek-v4-pro | $0.87 |
+| "Prove that the sum of two odd integers is even, step by step." | REASONING / reasoning | deepseek/deepseek-v4-pro | $3.96 |
 | "Cancel order B-42 and book the 9am flight to SFO." (tools attached) | AGENTIC / tool_agent_parallel | anthropic/claude-opus-4.8 | $25.00 |
 
 Note the second row: the REASONING primary is Grok 4.1 Fast Reasoning, but the portfolio ranked DeepSeek V4 Pro higher for this task shape. The tier primary is a starting point. Add `/model eco` and the SIMPLE row becomes a free NVIDIA-hosted model at $0.


### PR DESCRIPTION
## What

`/docs/products/intelligence/pricing` — the page a buyer reads before wiring up billing — has been quoting three prices below what the gateway charges:

| Row | Published | Real | Gap |
|---|---|---|---|
| DeepSeek V4 Pro | $0.43 / $0.87 | $1.32 / $3.96 | 3.1x in, 4.6x out |
| GPT-5.6 Terra Pro | $1.00 / $6.00 | $2.00 / $12.00 | 2x |
| GPT-5.6 Luna Pro | $0.10 / $0.60 | $0.20 / $1.20 | 2x |

Verified against live prod: `GET https://blockrun.ai/api/v1/models` returns `deepseek/deepseek-v4-pro` at `{input: 1.32, output: 3.96}`, while the docs page rendered `$0.43` / `$0.87`.

## Why it drifted

#69 did the DeepSeek reprice and the GPT-5.6 Pro corrections — but only in `api-reference/models.md` and `products/intelligence/overview.md`. This table was missed. The two Pro rows are the same SKUs whose stale catalog price made them unroutable in the gateway's #449: the catalog got fixed, this sheet did not.

Nothing went red because the gateway's `published-price-sync.test.ts` explicitly excluded this file, on the grounds that it was "deliberately POST-markup (x1.05)". That stopped being true on 2026-08-07 when the chat margin went to 0 — the exclusion outlived its reason and left the page unguarded.

## Also in this PR

- Adds the two DeepSeek SKUs the table never listed: **V4 Flash Reasoner** ($0.14/$0.28) and **V4 Flash Vision** ($0.44/$1.32, image input, shipped 08-30).
- `products/routing/clawrouter.md` — the routing example still showed `deepseek/deepseek-v4-pro` at `$0.87` output, while the worked example three sections below already used `$3.96`.

## Verification

Every priced row in `pricing.md` (41 of them) now round-trips against `src/lib/models.ts`, with 2dp rounding tolerance. The gateway PR that accompanies this one adds that as a test so the sheet cannot drift again — negative control confirmed: reverting the DeepSeek row to $0.43/$0.87 fails it.