### PR TITLE
docs: stop selling "no KYC" — say what is actually required

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ See [research/](./research/) for methodology.
 
 ## Vision
 
-**AI agents can't pay for services.** Traditional payment rails require account creation, credit cards, and KYC verification - none of which agents can do.
+**AI agents can't pay for services.** Traditional payment rails require account creation, credit cards, and identity verification - none of which agents can do.
 
 But agents have something better: **wallets**.
 
@@ -473,7 +473,7 @@ ClawRouter is an open-source (MIT licensed) smart LLM router built for autonomou
 BlockRun is agent-native — it uses wallet signatures for authentication instead of API keys, and USDC micropayments instead of credit cards. This means AI agents can operate autonomously without human intervention. BlockRun also includes ClawRouter for smart routing, third-party data & runtime services, and multi-chain support (Base + Solana).
 
 ### What is the x402 protocol?
-The x402 protocol is an HTTP-native payment standard based on HTTP status code 402 ("Payment Required"). It allows any HTTP request to include a cryptographic USDC payment, enabling machine-to-machine payments without accounts, credit cards, or KYC verification. BlockRun is a leading implementation of x402.
+The x402 protocol is an HTTP-native payment standard based on HTTP status code 402 ("Payment Required"). It allows any HTTP request to include a cryptographic USDC payment, enabling machine-to-machine payments without accounts, credit cards, or identity verification. BlockRun is a leading implementation of x402.
 
 ### How much does BlockRun cost?
 BlockRun uses pay-per-request pricing with no subscriptions. Per-token chat is billed at provider cost with no platform margin — only a flat $0.001 transaction fee is added per request; media generation and Live Search carry a 5% margin. Prices start at $0.002 per request for the cheapest data endpoints. $5 in USDC is enough for thousands of requests.

--- a/VISION.md
+++ b/VISION.md
@@ -9,7 +9,7 @@ The AI agent economy is growing exponentially, but there's a fundamental problem
 Traditional payment rails require:
 - Account creation (agents can't fill forms)
 - Credit cards (agents don't have bank accounts)
-- KYC verification (agents have no identity)
+- Identity verification (agents have no legal identity)
 - API key management (agents lose keys, keys get leaked)
 
 But agents have something better: **wallets**.
@@ -60,7 +60,7 @@ Route any x402 service through BlockRun:
 We believe the future is:
 
 1. **Agents as economic actors** - Agents earn, save, and spend
-2. **Wallet as identity** - No accounts, no passwords, no KYC
+2. **Wallet as identity** - No accounts, no passwords, no API keys
 3. **Micropayments at scale** - Pay per request, not per month
 4. **Trust through transparency** - Open ratings, open data
 

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -280,7 +280,7 @@ Seedance defaults to **720p with synced audio** for text-to-video; pass `resolut
 | `bytedance/seedance-2.5` | Seedance 2.5 | ~$0.315/sec ($1.58 / 5s clip) | 30s |
 | `azure/sora-2` | Sora 2 | $0.10/sec (4s = $0.42) | 12s |
 
-For character consistency across multiple Seedance videos, enroll a [Virtual Portrait](virtual-portrait.md) ($0.011 one-time, no KYC) for AI characters, or a [RealFace](realface.md) ($0.011 one-time, no KYC, requires brief on-phone liveness check) for real people. Pass the returned `ta_xxx` as `real_face_asset_id`.
+For character consistency across multiple Seedance videos, enroll a [Virtual Portrait](virtual-portrait.md) ($0.011 one-time, no government ID) for AI characters, or a [RealFace](realface.md) ($0.011 one-time, no government ID, requires brief on-phone liveness check) for real people. Pass the returned `ta_xxx` as `real_face_asset_id`.
 
 ## Model Categories
 

--- a/docs/api-reference/realface.md
+++ b/docs/api-reference/realface.md
@@ -1,13 +1,13 @@
 ---
 title: RealFace Enrollment
-description: Enroll a real person's face (no KYC, ~1-min on-phone liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0 Fast / 2.0 Mini videos.
+description: Enroll a real person's face (no government ID, ~1-min on-phone liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0 Fast / 2.0 Mini videos.
 ---
 
 # RealFace Enrollment
 
 Enroll a real person's face as a `ta_xxxxxxxx` asset you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0 Fast / 2.0 Mini call. Use this when you want **a real person to appear consistently across multiple videos** (talking head, spokesperson, character continuity).
 
-:::note{title="No KYC required"}
+:::note{title="Liveness check only"}
 No government ID, no account login, no name verification. Just a brief on-phone liveness check (nod + blink, ~1 minute) that proves the person enrolling is the same as the person in the photo. The biometric data is processed by the upstream identity service — BlockRun never sees it. For purely AI-generated characters (no real person involved), use [Virtual Portrait](virtual-portrait.md) instead ($0.011, no liveness step).
 :::
 
@@ -296,7 +296,7 @@ The video playground reads this same list and shows it in the `real_face_asset_i
 | Price | $0.011 USDC | $0.011 USDC |
 | Liveness check | Not required | Required (~1 minute on phone) |
 | Upstream verification | None | Biometric match against H5 live face |
-| KYC / government ID | Not required | Not required |
+| Government ID | Not required | Not required |
 | Compatible models | Seedance 2.0 / 2.0 Fast / 2.0 Mini | Seedance 2.0 / 2.0 Fast / 2.0 Mini |
 
 ## What's next?

--- a/docs/api-reference/video-generation.md
+++ b/docs/api-reference/video-generation.md
@@ -94,7 +94,7 @@ Whether you can seed generation from an image — and how — depends on the sub
 
 - **Non-human subject** (product, scene, animal, object): pass `image_url` (a public `https` URL to the first frame, or an inline `data:image/...;base64,` URI) on **`azure/sora-2`**, **Grok**, or any **Seedance** model. For `azure/sora-2` the gateway resizes the seed image server-side to Sora's exact required dimensions (1280×720 / 720×1280). Seedance image-to-video is billed at the same per-token rate as text-to-video.
 - **A specific real person**: you cannot upload a face to Sora (see the note below), and Seedance rejects a seed image that contains a real face (`400`, `code: "INPUT_IMAGE_REAL_PERSON"`). Use **Seedance 2.0 / 2.0-fast / 2.0-mini + a RealFace `ta_xxxx` asset** — enroll the person once *with their consent* ([RealFace](realface.md), ~1-min on-phone liveness, $0.011), then pass `real_face_asset_id`. Details in [Character consistency](#character-consistency-seedance-20-mini--fast--pro) below.
-- **An AI character / mascot**: same flow with a [Virtual Portrait](virtual-portrait.md) asset (no KYC, $0.011).
+- **An AI character / mascot**: same flow with a [Virtual Portrait](virtual-portrait.md) asset (no liveness step, $0.011).
 
 :::warning{title="Sora reference images cannot contain human faces"}
 `azure/sora-2` **rejects reference images that contain human faces** — a moderation pipeline blocks any recognizable person to prevent deepfakes, and there is no general human-likeness image-upload path. So on BlockRun: **`azure/sora-2` does image-to-video for non-human subjects** (`image_url`, resized server-side to Sora's exact dimensions); and **real-person video goes through Seedance 2.0 + RealFace** (the consent-based route above).
@@ -168,8 +168,8 @@ All prices below are the amounts quoted in the `402` challenge and actually bill
 
 | Action | Endpoint | Price |
 |---|---|---|
-| Virtual Portrait enrollment | [`POST /v1/portrait/enroll`](virtual-portrait.md) | $0.011 USDC per asset (no KYC) |
-| RealFace enrollment | [`POST /v1/realface/enroll`](realface.md) | $0.011 USDC per asset (no KYC, requires ~1-min on-phone liveness) |
+| Virtual Portrait enrollment | [`POST /v1/portrait/enroll`](virtual-portrait.md) | $0.011 USDC per asset (no government ID) |
+| RealFace enrollment | [`POST /v1/realface/enroll`](realface.md) | $0.011 USDC per asset (no government ID, requires ~1-min on-phone liveness) |
 
 ---
 
@@ -410,10 +410,12 @@ Pass a `ta_xxxx` asset from a Virtual Portrait or RealFace enrollment to keep th
 }
 ```
 
-| Asset type | Use when | KYC? | Liveness? | Cost | Enroll via |
-|---|---|---|---|---|---|
-| [**Virtual Portrait**](virtual-portrait.md) | AI character, mascot, avatar | No | No | $0.011 USDC | [`POST /v1/portrait/enroll`](virtual-portrait.md) · [studio/portrait](https://blockrun.ai/studio/portrait) |
-| [**RealFace**](realface.md) | Real person you have rights to | No | Yes (~1 min on phone) | $0.011 USDC (promo) | [`POST /v1/realface/init`](realface.md) + `/enroll` · [studio/realface](https://blockrun.ai/studio/realface) |
+| Asset type | Use when | Liveness? | Cost | Enroll via |
+|---|---|---|---|---|
+| [**Virtual Portrait**](virtual-portrait.md) | AI character, mascot, avatar | No | $0.011 USDC | [`POST /v1/portrait/enroll`](virtual-portrait.md) · [studio/portrait](https://blockrun.ai/studio/portrait) |
+| [**RealFace**](realface.md) | Real person you have rights to | Yes (~1 min on phone) | $0.011 USDC (promo) | [`POST /v1/realface/init`](realface.md) + `/enroll` · [studio/realface](https://blockrun.ai/studio/realface) |
+
+Neither needs a government ID.
 
 ---
 
@@ -450,11 +452,11 @@ Set your HTTP client timeout to at least 60s per request (the poll that complete
 ::::cards
 
 :::card{title="Virtual Portrait" href="virtual-portrait.md" icon="Boxes"}
-Zero-KYC `ta_xxx` enrollment for AI-character consistency across clips.
+`ta_xxx` enrollment for AI-character consistency across clips — no government ID, no liveness.
 :::
 
 :::card{title="RealFace Enrollment" href="realface.md" icon="Image"}
-Real-person likeness with on-phone liveness — still no KYC.
+Real-person likeness with on-phone liveness — no government ID.
 :::
 
 :::card{title="Image Generation" href="image-generation.md" icon="Image"}

--- a/docs/api-reference/virtual-portrait.md
+++ b/docs/api-reference/virtual-portrait.md
@@ -1,14 +1,14 @@
 ---
 title: Virtual Portrait Enrollment
-description: Enroll an AI-generated character (no KYC, no liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0 Fast / 2.0 Mini videos — $0.011 USDC.
+description: Enroll an AI-generated character (no government ID, no liveness) as a ta_xxx asset for consistent likeness across Seedance 2.0 / 2.0 Fast / 2.0 Mini videos — $0.011 USDC.
 ---
 
 # Virtual Portrait Enrollment
 
-Enroll an AI-generated character image as a Virtual Portrait and get back a `ta_xxxxxxxx` id you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0 Fast / 2.0 Mini call. Use this when you want **the same character across multiple videos** without dealing with KYC.
+Enroll an AI-generated character image as a Virtual Portrait and get back a `ta_xxxxxxxx` id you can pass as `real_face_asset_id` on any Seedance 2.0 / 2.0 Fast / 2.0 Mini call. Use this when you want **the same character across multiple videos** without a liveness check.
 
-:::note{title="No KYC required"}
-Use this for AI-generated personas, mascots, avatars, virtual spokespeople — no liveness step needed because the asset is understood to be a synthetic character. For **real-person likeness**, use [RealFace](realface.md) (also no KYC, but requires a brief liveness check on the rights-holder's phone to prove consent).
+:::note{title="No liveness check"}
+Use this for AI-generated personas, mascots, avatars, virtual spokespeople — no liveness step needed because the asset is understood to be a synthetic character. For **real-person likeness**, use [RealFace](realface.md) (also no government ID, but requires a brief liveness check on the rights-holder's phone to prove consent).
 :::
 
 | | |
@@ -198,7 +198,7 @@ Pass the `ta_xxx` you just enrolled as `real_face_asset_id` on a Seedance call.
 :::
 
 :::card{title="RealFace Enrollment" href="realface.md" icon="Boxes"}
-Same `ta_xxx` mechanic but for a real person — requires liveness, still no KYC.
+Same `ta_xxx` mechanic but for a real person — requires liveness, still no government ID.
 :::
 
 :::card{title="x402 Payment Flow" href="../x402/payment-flow.md" icon="Zap"}

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -539,7 +539,7 @@ status = voice.get_status(call["call_id"])   # free; transcript + recording_url 
 ```python
 from blockrun_llm import PortraitClient, RealFaceClient
 
-# Virtual Portrait — AI character, no KYC, $0.011 one-time
+# Virtual Portrait — AI character, no liveness check, $0.011 one-time
 portrait = PortraitClient()
 p = portrait.enroll("My Spokesperson", "https://example.com/character.jpg")
 print(p.asset_id)   # ta_xxxxxxxx → pass to VideoClient(real_face_asset_id=...)


### PR DESCRIPTION
Owner ruling: stop writing "No KYC" anywhere. It is a compliance term that means nothing to a buyer and reads as evasion. `/services/seedance` in the site repo made this call on 2026-09-02 and left the reasoning in a comment; this extends it to the docs the site serves at `/docs`.

**These are live and indexed right now.** `realface.md:3` and `virtual-portrait.md:3` frontmatter *are* the pages' `<meta name="description">` on blockrun.ai:

```
$ curl -s https://blockrun.ai/docs/api-reference/realface | grep -o '<meta name="description"[^>]*>'
<meta name="description" content="Enroll a real person&#x27;s face (no KYC, ~1-min on-phone liveness) …"/>
```

## What changed — 17 sites across 7 files

The rule: delete the term, keep the fact. Where a sentence already listed the specifics ("no government ID, no account login, no name verification"), the `No KYC` lead-in was deleted outright rather than substituted — the specifics say it better and more credibly.

- **Frontmatter descriptions** on `realface.md` and `virtual-portrait.md`.
- **Both `:::note{title="No KYC required"}` callouts** retitled to **"Liveness check only"** (RealFace) and **"No liveness check"** (Virtual Portrait). Two different products were carrying the same headline, which actively obscured the one axis on which they differ; the retitled pair now makes that contrast the first thing rendered on either page.
- `realface.md:299` comparison row `KYC / government ID` → `Government ID`.
- `video-generation.md` — the `KYC?` table column header, plus lines 97, 171, 172, 453, 457.
- `models.md:283`, `sdks/python.md:542`.
- `VISION.md:12,63` and `README.md:412,476` carried the same claim outside `docs/`, where neither repo's guard could see it.

## Kept — ordinary-sense uses, not our claim

- `kyc.byteintl.com` in the `/v1/realface/init` example payloads — a hostname; changing it would falsify a documented response body.
- `voice-phone.md:20,78,80,410` — Twilio carrier Regulatory Bundle approval. A real operational constraint we have to disclose.
- `surf.md:253` — a comparison row describing what an *alternative* requires.
- **Every dated `resources/changelog.md` entry.** This repo's rule: a dated post is a measurement, not a claim, and rewriting one misrepresents what was published that day. Zero diff on that file.

## Facts verified intact

RealFace still states its ~1-minute on-phone liveness check (nod + blink) on every surface that mentions it; Virtual Portrait still states it requires none. No `title:` frontmatter, heading, anchor slug, URL or price was touched.

## Landing

The site repo's `fix/drop-no-kyc-claim` carries a guard test that sweeps `docs/**` for exactly this claim. Verified load-bearing: against the currently-pinned docs tree it fails with 17 unexempted hits; against this branch it passes 13/13. **That PR bumps the submodule pointer, so this one lands first.**