### PR TITLE
docs: stop naming the upstream conduit, and stop pricing against it

### DIFF
--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -63,7 +63,7 @@ Only models that are currently available are returned — there is no `available
 **71 chat / LLM models** are publicly listed on mainnet, plus **9 image**, **8 video**, **1 music**, **5 text-to-speech**, and **1 sound-effects** model — covering chat, image, video, music, speech, and sound-effects generation from one API. Additional deprecated / superseded LLM IDs remain routable for backwards compatibility but are hidden from the catalog. Call `GET /api/v1/models` for the exact live list.
 :::
 
-All prices shown are provider rates — and, for per-token chat, also the billed rates: BlockRun adds **no platform margin** on chat tokens (we match OpenRouter), only the flat $0.001/request transaction fee. Media and Live Search still carry a 5% platform fee.
+All prices shown are provider rates — and, for per-token chat, also the billed rates: BlockRun adds **no platform margin** on chat tokens, only the flat $0.001/request transaction fee. Media and Live Search still carry a 5% platform fee.
 
 ### OpenAI GPT-5.6 Family
 

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -21,7 +21,7 @@ No API keys. No monthly bills. Just usage-based payments in USDC.
 
 ## Available Models
 
-Provider rates per 1M tokens. Since 2026-08-07 these are also the BILLED rates — per-token chat carries no platform margin (we match OpenRouter); only the flat $0.001/request transaction fee is added. See [Pricing](pricing.md).
+Provider rates per 1M tokens. Since 2026-08-07 these are also the BILLED rates — per-token chat carries no platform margin; only the flat $0.001/request transaction fee is added. See [Pricing](pricing.md).
 
 ### OpenAI
 | Model | Input | Output |

--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -10,7 +10,7 @@ Pay only for what you use. Per-token chat is billed at **provider cost** — no 
 ## Pricing Formula
 
 ```
-Your cost = Provider cost          (per-token chat — no margin, matches OpenRouter)
+Your cost = Provider cost          (per-token chat — no platform margin)
               + $0.001 / request     (flat x402 transaction fee)
 ```
 

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -11,7 +11,7 @@ All notable changes to BlockRun, newest first — gateway endpoints, model lineu
 
 ### Added — Qwen3.8 Flash, DeepSeek V4 Flash Vision, MiMo-V2.5
 - **`qwen/qwen3.8-flash`** ($0.15/M in · $0.47/M out, 1M context, **image input**) — 125B MoE with GDN+QSA hybrid attention. Alibaba positions it above Qwen3.7 **Plus**, which we sell at $0.32/$1.28, so it is both newer and cheaper than the tier it beats.
-- **`deepseek/deepseek-v4-flash-vision-exp`** ($0.44/M · $1.32/M, 1M context, **image input**) — our first DeepSeek model that takes images. Served direct from DeepSeek; the OpenRouter route is unavailable under our account's data policy. Priced at DeepSeek's **peak** rate, since their new peak/off-peak split (peak 01:00–04:00 and 06:00–10:00 UTC, Mon–Fri) would otherwise put it below cost for seven hours every weekday.
+- **`deepseek/deepseek-v4-flash-vision-exp`** ($0.44/M · $1.32/M, 1M context, **image input**) — our first DeepSeek model that takes images. Priced at DeepSeek's **peak** rate, since their new peak/off-peak split (peak 01:00–04:00 and 06:00–10:00 UTC, Mon–Fri) would otherwise put it below cost for seven hours every weekday.
 - **`xiaomi/mimo-v2.5`** ($0.14/M · $0.28/M, 1M context, **image input**) — the natively multimodal MiMo SKU, distinct from (and a third the price of) the text-only `mimo-v2.5-pro` we already listed.
 - All three were probe-verified with real completions — and real image input — before listing.
 
@@ -27,7 +27,7 @@ All notable changes to BlockRun, newest first — gateway endpoints, model lineu
 - Also 410: the hidden **`nvidia/nemotron-super-49b`**, which was simultaneously the free cascade's tertiary rung and the fallback of its primary — both retargeted in the same change.
 - Added **`nvidia/nemotron-3.5-lightning`** (thinking-mode reasoning, 131K context, ~35 tok/s), **`nvidia/nemotron-3-nano-30b`** (~121 tok/s, the fastest free model in the catalog) and **`nvidia/llama-3.2-11b-vision`** (Meta Llama 3.2, 128K context, image input) — each verified with a real completion through the gateway before listing.
 - **`nvidia/gpt-oss-120b`** and **`nvidia/gpt-oss-20b`** recovered upstream and no longer redirect elsewhere.
-- **`nvidia/nemotron-3.5-lightning`** and **`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`** now serve from OpenRouter's $0 pool with the direct-NVIDIA path as their fallback — same models, larger capacity pool, 4.9s median against 16.3s, and Lightning gains a **1M-token context** (was 131K). Image input verified through the new route before moving the vision model.
+- **`nvidia/nemotron-3.5-lightning`** and **`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`** now serve from a larger free-tier capacity pool, with their previous route kept as the fallback — same models, 4.9s median against 16.3s, and Lightning gains a **1M-token context** (was 131K). Image input verified through the new route before moving the vision model.
 - Added three more free models: **`nvidia/nemotron-3-ultra-550b`** (550B/55B MoE, **1M context** — the largest free model in the catalog, and unreachable on our own NVIDIA key), **`cohere/north-mini-code`** (compact coding, sub-second) and **`poolside/laguna-xs-2.1`** (coding, ~161 tok/s).
 - Visible chat models are now **73** (was 71); total catalog **97**; free models **7** (was 5).
 
@@ -184,10 +184,10 @@ All notable changes to BlockRun, newest first — gateway endpoints, model lineu
 ## [2026-07-13]
 
 ### Added — xAI Grok 4.5
-- Added **`xai/grok-4.5`** ($2.50/$9.00 per 1M, 500K context, vision + reasoning), xAI's flagship. Live Search supported (+$0.025/source). Verified with real completions on both the direct-xAI and OpenRouter routes before listing.
+- Added **`xai/grok-4.5`** ($2.50/$9.00 per 1M, 500K context, vision + reasoning), xAI's flagship. Live Search supported (+$0.025/source). Verified with real completions on every serving route before listing.
 
 ### Changed — Grok long-context pricing now mirrors xAI's official 2x tier
-- xAI (and OpenRouter) bill the Grok family at **2x above 200K prompt tokens**. BlockRun now applies the same tier: once a request's prompt reaches 200K tokens, the whole request reprices at the long-context rate — `grok-4.5` $5.00/$18.00, `grok-4.3` $3.00/$8.00, `grok-build-0.1` $3.00/$6.00, `grok-4.20` $4.00/$12.00 per 1M. Below 200K, base rates are unchanged.
+- xAI bills the Grok family at **2x above 200K prompt tokens**. BlockRun now applies the same tier: once a request's prompt reaches 200K tokens, the whole request reprices at the long-context rate — `grok-4.5` $5.00/$18.00, `grok-4.3` $3.00/$8.00, `grok-build-0.1` $3.00/$6.00, `grok-4.20` $4.00/$12.00 per 1M. Below 200K, base rates are unchanged.
 - `grok-4.5` fallback set to `grok-4.20-reasoning` (Live-Search-capable) so a failover never silently drops search.
 
 ---

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -269,7 +269,7 @@ All notable changes to BlockRun, newest first — gateway endpoints, model lineu
 ## [2026-05-24 — late]
 
 ### Changed — Virtual Portrait enrollment dropped to $0.01 (parity with RealFace)
-- **`POST /api/v1/portrait/enroll`**: $0.50 → **$0.01 USDC**. Token360 charges nothing for asset storage, so per-enrollment margin was always trivial; the old $0.50 was friction without offsetting cost. Now matches RealFace pricing — both are 1¢ to encourage adoption, and we make our money on the downstream Seedance per-clip revenue.
+- **`POST /api/v1/portrait/enroll`**: $0.50 → **$0.01 USDC**. Storing an enrolment costs us nothing, so per-enrollment margin was always trivial; the old $0.50 was friction without offsetting cost. Now matches RealFace pricing — both are 1¢ to encourage adoption, and we make our money on the downstream Seedance per-clip revenue.
 - All UI, docs, video-playground tooltips, and asset-storage comments updated to reflect the new price.
 
 ## [2026-05-24]


### PR DESCRIPTION
Vicky, 2026-09-03: 「我们现在官网还说我们的背后就是 openrouter 这个要改啊」. Two separate leaks, both public.

## 1. Routing disclosure (`docs/resources/changelog.md`)

The changelog named the wholesale conduit four times:

| Line | What it said |
|---|---|
| 30 | two free models *"serve from **OpenRouter's $0 pool**"* |
| 14 | *"the **OpenRouter** route is unavailable under **our account's data policy**"* — the conduit *and* our account state |
| 187 | grok-4.5 *"verified on both the direct-xAI and **OpenRouter** routes"* |
| 190 | the long-context tier attributed to *"xAI (and **OpenRouter**)"* |

This is the same leak class `src/lib/models-description-leak.test.ts` already pins for model `description` fields, just written in prose instead of data.

**Every measurement survives.** The free-tier entry keeps 4.9s against 16.3s and the 1M-token context; it now says the models moved to a larger free-tier pool with their previous route as the fallback — the part a caller can actually act on.

## 2. Price parity

`we match OpenRouter` / `no margin, matches OpenRouter` appeared on the pricing sheet, the intelligence overview and the models API reference. It reads as *"OpenRouter is what is behind us."*

The claim carrying the weight is **0% platform margin on chat tokens**, and each of those sentences already states it in full — the competitor's name was doing no work, so it is deleted rather than reworded.

## Not touched

Comparison pages. Naming OpenRouter as a competitor is deliberate positioning, not a routing disclosure — the same distinction `models-description-leak.test.ts` draws.

After this, `grep -ri openrouter docs/` returns nothing outside ClawRouter.