### PR TITLE
docs: Gemini 3.8 Flash, corrected 3.6 Flash pricing, counts to 75/99

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ description: BlockRun is the routing and payment layer for AI agents — one end
 
 **Agents that pay, spend, and trade.**
 
-BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 74 LLMs, media generation, real-time data, and on-chain execution.
+BlockRun is economic infrastructure for the agent era. AI agents discover services, pay in USDC over the [x402 protocol](x402/how-it-works.md), and execute autonomously — **no API keys, no subscriptions, no credit card.** One funded wallet unlocks 75 LLMs, media generation, real-time data, and on-chain execution.
 
 :::tip{title="In a hurry?"}
 Jump to the [5-Minute Quickstart](getting-started/quickstart.md) and make your first paid call.
@@ -38,7 +38,7 @@ Pick the path that matches how you work.
 ::::cards
 
 :::card{title="I want an autonomous agent" href="products/franklin.md" icon="Rocket"}
-Franklin — the AI agent with a wallet. Writes code and spends USDC across 74 models and paid APIs. Free to start.
+Franklin — the AI agent with a wallet. Writes code and spends USDC across 75 models and paid APIs. Free to start.
 :::
 
 :::card{title="I use Claude Code / Cursor" href="getting-started/quickstart.md" icon="Terminal"}
@@ -62,7 +62,7 @@ Four product families, one payment layer.
 ::::cards
 
 :::card{title="Intelligence" href="products/intelligence/overview.md" icon="Brain"}
-74 LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
+75 LLMs (GPT, Claude, Gemini, DeepSeek, Grok, Kimi, Llama) through one OpenAI-compatible API. Pay per request.
 :::
 
 :::card{title="Routing" href="products/routing/clawrouter.md" icon="Route"}

--- a/docs/api-reference/chat-completions.md
+++ b/docs/api-reference/chat-completions.md
@@ -1,6 +1,6 @@
 ---
 title: Chat Completions
-description: OpenAI-compatible Chat Completions endpoint for 74 LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
+description: OpenAI-compatible Chat Completions endpoint for 75 LLMs, paid per request in USDC over x402 — no API keys, no subscriptions.
 ---
 
 # Chat Completions
@@ -336,7 +336,7 @@ console.log(result.choices[0].message.content);
 ::::cards
 
 :::card{title="Browse all models" href="models.md" icon="Brain"}
-74 chat models with live pricing — pick the right model and ID for your call.
+75 chat models with live pricing — pick the right model and ID for your call.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/exa-search.md
+++ b/docs/api-reference/exa-search.md
@@ -393,7 +393,7 @@ Real-time web and news search via Grok Live Search.
 :::
 
 :::card{title="Chat Completions" href="chat-completions.md" icon="Brain"}
-Feed grounded search results into any of 74 LLMs for synthesis.
+Feed grounded search results into any of 75 LLMs for synthesis.
 :::
 
 :::card{title="Error handling" href="errors.md" icon="Code"}

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -150,7 +150,8 @@ These models reject all sampling parameters (`temperature`, `top_p`, `top_k`); t
 | `google/gemini-3.1-pro` | Gemini 3.1 Pro | $2.00/M | $12.00/M | 1M |
 | `google/gemini-2.5-pro` | Gemini 2.5 Pro | $1.25/M | $10.00/M | 1M |
 | `google/gemini-3.5-flash` | Gemini 3.5 Flash | $1.50/M | $9.00/M | 1M |
-| `google/gemini-3.6-flash` | Gemini 3.6 Flash | $1.50/M | $7.50/M | 1M |
+| `google/gemini-3.8-flash` | Gemini 3.8 Flash | $0.75/M | $3.75/M | 1M |
+| `google/gemini-3.6-flash` | Gemini 3.6 Flash | $0.75/M | $3.75/M | 1M |
 | `google/gemini-3-flash-preview` | Gemini 3 Flash Preview | $0.50/M | $3.00/M | 1M |
 | `google/gemini-2.5-flash` | Gemini 2.5 Flash | $0.30/M | $2.50/M | 1M |
 | `google/gemini-3.5-flash-lite` | Gemini 3.5 Flash Lite | $0.30/M | $2.50/M | 1M |

--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -1,6 +1,6 @@
 ---
 title: AgentKit Integration
-description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 98 AI models.
+description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 99 AI models.
 ---
 
 # AgentKit Integration
@@ -21,7 +21,7 @@ AgentKit provides:
 - Framework extensions (`coinbase-agentkit-langchain`, …)
 
 BlockRun adds:
-- 74 chat models (95 in the full catalog)
+- 75 chat models (95 in the full catalog)
 - Pay-per-request intelligence
 - No API key management
 

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -1,17 +1,17 @@
 ---
 title: ElizaOS Integration
-description: Add the BlockRun plugin to ElizaOS so your agents reach 98 AI models via x402 micropayments — no per-provider API keys.
+description: Add the BlockRun plugin to ElizaOS so your agents reach 99 AI models via x402 micropayments — no per-provider API keys.
 ---
 
 # ElizaOS Integration
 
-Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 74 models paid per request over x402.
+Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 75 models paid per request over x402.
 
 :::note{title="Community integration"}
 BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
 :::
 
-[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 98 AI models via x402 micropayments.
+[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 99 AI models via x402 micropayments.
 
 ## Setup
 

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -1,11 +1,11 @@
 ---
 title: GOAT SDK Integration
-description: Combine GOAT SDK's cross-chain execution with BlockRun's 98 AI models, paid per request over x402 — until the official plugin ships.
+description: Combine GOAT SDK's cross-chain execution with BlockRun's 99 AI models, paid per request over x402 — until the official plugin ships.
 ---
 
 # GOAT SDK Integration
 
-Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 74 models with x402 micropayments.
+Use BlockRun with [GOAT SDK](https://github.com/crossmint/goat) (Great Onchain Agent Toolkit) for cross-chain AI agents. GOAT handles blockchain interactions, BlockRun provides AI intelligence via 75 models with x402 micropayments.
 
 :::note{title="Community integration — pre-release"}
 No official `@goat-sdk/plugin-blockrun` yet; use BlockRun alongside GOAT via the [TypeScript SDK](../sdks/typescript.md) as shown below. BlockRun's primary paths are [Franklin](../products/franklin.md), the [MCP](../mcp/blockrun-mcp.md), and the SDKs.
@@ -129,7 +129,7 @@ const { text } = await generateText({
 | GOAT Provides | BlockRun Adds |
 |---------------|---------------|
 | Cross-chain execution | AI decision making |
-| Protocol integrations | 74 chat models (95 total) |
+| Protocol integrations | 75 chat models (95 total) |
 | Wallet management | Pay-per-request AI |
 | Transaction building | No API key hassle |
 

--- a/docs/frameworks/langchain.md
+++ b/docs/frameworks/langchain.md
@@ -1,6 +1,6 @@
 ---
 title: LangChain Integration
-description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 74 models.
+description: Wrap BlockRun in a custom LangChain LLM class that handles x402 payments automatically — chains, agents, and RAG over 75 models.
 ---
 
 # LangChain Integration

--- a/docs/getting-started/agent-developers.md
+++ b/docs/getting-started/agent-developers.md
@@ -1,13 +1,13 @@
 ---
 title: Agent Developers
-description: Build AI agents that pay for their own intelligence — 74 models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
+description: Build AI agents that pay for their own intelligence — 75 models via x402 micropayments. Use Franklin, the SDKs, or the MCP; integrate with frameworks if you already use one.
 ---
 
 # Agent Developers
 
 Build AI agents that pay for their own intelligence.
 
-This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 74 models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
+This guide is for agent developers. The primary paths are **[Franklin](../products/franklin.md)** (our autonomous agent), the **[SDKs](../sdks/python.md)**, and the **[BlockRun MCP](../mcp/blockrun-mcp.md)** — all on one wallet, 75 models via x402 micropayments. Already using a framework (ElizaOS, AgentKit, GOAT, LangChain)? See [Community integrations](../frameworks/elizaos.md).
 
 :::tip{title="Fastest path: Franklin"}
 Want an agent that already spends autonomously? [Franklin](../products/franklin.md) is one install (`npm install -g @blockrun/franklin`) and runs free out of the box — fund a wallet to unlock everything.

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Code Users
-description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 74 models, images, and live data.
+description: Install BlockRun MCP in Claude Code, fund a wallet with USDC on Base or Solana, and give your agent 75 models, images, and live data.
 ---
 
 # Claude Code Users
@@ -273,7 +273,7 @@ Create images via micropayments with `blockrun_image`.
 :::
 
 :::card{title="Explore all models" href="../products/intelligence/overview.md" icon="Brain"}
-74 LLMs with live pricing, plus smart routing to cut costs automatically.
+75 LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 ::::

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -108,7 +108,7 @@ The full list of 20 `blockrun_*` tools — chat, image, video, search, markets, 
 :::
 
 :::card{title="Explore the models" href="../products/intelligence/overview.md" icon="Brain"}
-74 LLMs with live pricing, plus smart routing to cut costs automatically.
+75 LLMs with live pricing, plus smart routing to cut costs automatically.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -1,11 +1,11 @@
 ---
 title: BlockRun MCP
-description: A Model Context Protocol server that gives Claude Code 74 models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
+description: A Model Context Protocol server that gives Claude Code 75 models, crypto data, voice calls, media generation, and prediction markets with zero API keys.
 ---
 
 # BlockRun MCP
 
-Give Claude Code access to 98 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 99 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 

--- a/docs/products/franklin.md
+++ b/docs/products/franklin.md
@@ -1,6 +1,6 @@
 ---
 title: Franklin Agent
-description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 74 models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
+description: Franklin is the AI agent with a wallet — it writes code and spends USDC autonomously across 75 models and paid APIs, settling per outcome over x402. No subscriptions, no API keys.
 ---
 
 # Franklin Agent
@@ -116,7 +116,7 @@ Inside a session: `/model`, `/plan` / `/execute`, `/ultrathink`, `/compact`, `/c
 
 Franklin is the autonomous agent on top of the BlockRun stack — it uses the same pieces you can use directly:
 
-- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 74 chat models. Four profiles: `auto`, `eco`, `premium`, `free`.
+- **Models & routing** — picks the best model per task via [ClawRouter](routing/clawrouter.md)'s scoring, across 75 chat models. Four profiles: `auto`, `eco`, `premium`, `free`.
 - **Paid APIs** — search, market data, media, RPC, prediction markets and more, paid per call over [x402](../x402/how-it-works.md).
 - **One wallet** — the wallet is the identity; fund it on Solana or Base ([Wallet Setup](../getting-started/wallet-setup.md)).
 

--- a/docs/products/intelligence/overview.md
+++ b/docs/products/intelligence/overview.md
@@ -1,11 +1,11 @@
 ---
 title: Intelligence
-description: BlockRun Intelligence gives your agent 74 LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
+description: BlockRun Intelligence gives your agent 75 LLMs through one OpenAI-compatible API, paid per request in USDC — no API keys, no subscriptions.
 ---
 
 # Intelligence
 
-AI accesses any LLM. 74 models, pay-per-request.
+AI accesses any LLM. 75 models, pay-per-request.
 
 BlockRun's Intelligence product gives your AI agent access to models from OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and more — without managing API keys or subscriptions.
 

--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -70,7 +70,8 @@ The free tier costs $0 — 5 reasoning, coding, and vision models with no per-to
 | Model | Input (per 1M) | Output (per 1M) |
 |-------|---------------|-----------------|
 | Gemini 3.1 Pro | $2.00 | $12.00 |
-| Gemini 3.6 Flash | $1.50 | $7.50 |
+| Gemini 3.8 Flash | $0.75 | $3.75 |
+| Gemini 3.6 Flash | $0.75 | $3.75 |
 | Gemini 3.5 Flash | $1.50 | $9.00 |
 | Gemini 3.5 Flash Lite | $0.30 | $2.50 |
 

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -7,7 +7,7 @@ description: ClawRouter is a smart LLM router for OpenClaw that picks the optima
 
 **84% cheaper than pinning one flagship for every request — 98% on `eco`. Automatically.**
 
-ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 74 models, zero API keys.
+ClawRouter is a smart LLM router for OpenClaw that routes every request to the cheapest model that can handle it. One wallet, 75 models, zero API keys.
 
 :::tip{title="In a hurry?"}
 Install, fund a wallet, then run `/model blockrun/auto` in any OpenClaw conversation — that's it. Current release: **v0.12.253** (August 29, 2026).
@@ -228,7 +228,7 @@ Note the second row: the REASONING primary is Grok 4.1 Fast Reasoning, but the p
 - No external API calls for routing decisions
 - Full privacy - your prompts never leave your machine for routing
 
-### 74 Models
+### 75 Models
 
 Access all major providers through one wallet:
 
@@ -586,7 +586,7 @@ No. AI model access requires internet. But routing decisions are made locally.
 ::::cards
 
 :::card{title="View all models" href="../intelligence/overview.md" icon="Brain"}
-74 LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and the free tier.
+75 LLMs across OpenAI, Anthropic, Google, xAI, DeepSeek, Z.AI, Moonshot, MiniMax, and the free tier.
 :::
 
 :::card{title="Check pricing" href="../intelligence/pricing.md" icon="Zap"}

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -18,7 +18,7 @@ Run any GPT-Image-2 or Seedance prompt as a one-liner — `/headshot`, `/dance`,
 :::
 
 :::card{title="lobster.cash skill" href="https://github.com/BlockRunAI/lobstercash-blockrun-skill" icon="Zap"}
-BlockRun skill for the lobster.cash OpenClaw plugin — 74 models paid with Solana USDC.
+BlockRun skill for the lobster.cash OpenClaw plugin — 75 models paid with Solana USDC.
 :::
 
 :::card{title="blockrun-claude-plugin" href="https://github.com/BlockRunAI/blockrun-claude-plugin" icon="Wallet"}

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -121,7 +121,7 @@ Yes — a flat $0.001 transaction fee on every paid call, which covers on-chain 
 
 ### Which AI models are available?
 
-74 models including:
+75 models including:
 - OpenAI (GPT-5.5, GPT-5.4, GPT-5.4 Pro, GPT-5.2)
 - Anthropic (Claude Opus 5, Opus 4.8, Sonnet 5, Sonnet 4.6, Haiku 4.5)
 - Google (Gemini 3.1 Pro, Gemini 3.5 Flash)

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -1,11 +1,11 @@
 ---
 title: Go SDK
-description: The Go SDK for BlockRun — call 98 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
+description: The Go SDK for BlockRun — call 99 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
 ---
 
 # Go SDK
 
-The Go SDK for BlockRun provides access to 98 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
+The Go SDK for BlockRun provides access to 99 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
 
 **Source:** [github.com/BlockRunAI/blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go) · `go get github.com/BlockRunAI/blockrun-llm-go@v0.20.0` · Go 1.22+ · MIT
 
@@ -516,7 +516,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 74 models with live pricing to pick the right one for each call.
+Browse all 75 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python SDK
-description: The official BlockRun Python SDK — call 74 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun Python SDK — call 75 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # Python SDK
@@ -1069,7 +1069,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 74 models with live pricing to pick the right one for each call.
+Browse all 75 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: TypeScript SDK
-description: The official BlockRun TypeScript/JavaScript SDK — call 74 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
+description: The official BlockRun TypeScript/JavaScript SDK — call 75 LLMs, smart routing, and prediction markets over x402 micropayments with no API keys.
 ---
 
 # TypeScript SDK
@@ -934,7 +934,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 74 models with live pricing to pick the right one for each call.
+Browse all 75 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -433,7 +433,7 @@ Fund a wallet with USDC and make your first paid call in under five minutes.
 :::
 
 :::card{title="Models & pricing" href="../api-reference/models.md" icon="Brain"}
-Browse all 74 models with live pricing to pick the right one for each call.
+Browse all 75 models with live pricing to pick the right one for each call.
 :::
 
 :::card{title="How payment works" href="../x402/how-it-works.md" icon="Zap"}

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -41,7 +41,7 @@ Replace `blockrun.ai` with `sol.blockrun.ai`, `nano.blockrun.ai`, or `testnet.bl
 
 ## AI Model Gateway
 
-OpenAI-compatible. 74 models across chat, reasoning, coding, and vision — plus image, video, music, and speech generation. Per-model pricing is published live at `/api/v1/models`.
+OpenAI-compatible. 75 models across chat, reasoning, coding, and vision — plus image, video, music, and speech generation. Per-model pricing is published live at `/api/v1/models`.
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|


### PR DESCRIPTION
Companion to the gateway PR adding `google/gemini-3.8-flash`.

## What changed

- **New model** — `google/gemini-3.8-flash` at $0.75/$3.75 per 1M, 1M context, added to the model reference and the pricing sheet.
- **Corrected price** — Gemini 3.6 Flash was published at $1.50/$7.50. Google put the whole 3.6/3.7/3.8 Flash band on a promotional rate through 2026-12-31 and the docs never followed, so the published price was ~2x the real one. Now $0.75/$3.75.
- **Counts** — 74 → 75 chat, 98 → 99 total, across 21 files.

Both price changes are pinned by `published-price-sync.test.ts` in the gateway repo, and the counts by `brand-numbers.docs.test.ts`; both were red before this and are green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSAx2r1y79mm5W2Sh85pFD