### PR TITLE
docs(surf): 66 endpoints, and the Social family is gone

### DIFF
--- a/docs/api-reference/defillama.md
+++ b/docs/api-reference/defillama.md
@@ -166,7 +166,7 @@ never costs you anything.
 ::::cards
 
 :::card{title="Surf — Crypto Data" href="surf.md" icon="ChartLine"}
-Exchange, on-chain and social data across 83 endpoints.
+Exchange and on-chain data across 66 endpoints.
 :::
 
 :::card{title="0x Swap (DEX)" href="zerox-swap.md" icon="ArrowLeftRight"}

--- a/docs/api-reference/surf.md
+++ b/docs/api-reference/surf.md
@@ -5,7 +5,7 @@ description: 83 crypto-data endpoints (CEX, on-chain SQL, prediction markets, wa
 
 # Surf — Crypto Data API
 
-Real-time crypto data for AI agents. 83 endpoints across exchanges, on-chain analytics, prediction markets, wallet labels, social mindshare, news, and search — all priced per call in USDC. No Surf account, no API key, just a wallet.
+Real-time crypto data for AI agents. 66 endpoints across exchanges, on-chain analytics, prediction markets, wallet labels, news, and search — all priced per call in USDC. No Surf account, no API key, just a wallet.
 
 Powered by [Surf](https://asksurf.ai) (asksurf.ai). BlockRun proxies the same endpoints with x402 settlement, and every call is priced the same flat rate — the price you see in the 402 is the price you pay.
 
@@ -17,7 +17,7 @@ Surf unifies all of it behind one schema, billed per-call in stablecoins. An age
 
 ## Endpoints by Category
 
-83 endpoints organized across 12 domains. **Three flat price tiers:**
+66 endpoints organized across 11 domains. **Three flat price tiers:**
 
 | Tier | Price | Use case |
 |------|-------|----------|
@@ -251,7 +251,7 @@ Every price above is the full customer price: $0.0075 base + the flat $0.001 tra
 | Payment | USDC per call | Subscription | Subscription | Subscription |
 | Account required | No | Yes | Yes | Yes |
 | Works for autonomous agents | ✅ | ❌ (API key, KYC) | ❌ | ❌ |
-| Coverage | 83 endpoints across 12 categories | Same upstream | Prices only | SQL only |
+| Coverage | 66 endpoints across 11 categories | Same upstream | Prices only | SQL only |
 | On-chain SQL | ✅ ($0.0085/query) | ✅ | ❌ | ✅ ($$$) |
 | Same wallet as LLM calls | ✅ | N/A | N/A | N/A |
 

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -134,7 +134,7 @@ Top 10 tokens by DEX volume on Base, last 24h
 Call eth_getBalance on Arbitrum for 0x...
 ```
 
-`blockrun_surf` (exchange, on-chain SQL, wallet labels, social mindshare), `blockrun_price` (Pyth-backed quotes), `blockrun_dex`, `blockrun_defi` (TVL, yields), and `blockrun_rpc` (raw JSON-RPC on 40 chains). The `crypto-data` skill says which one to use.
+`blockrun_surf` (exchange, on-chain SQL, wallet labels, prediction markets), `blockrun_price` (Pyth-backed quotes), `blockrun_dex`, `blockrun_defi` (TVL, yields), and `blockrun_rpc` (raw JSON-RPC on 40 chains). The `crypto-data` skill says which one to use.
 
 ### Phone Calls and Sandboxed Compute
 

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -5,7 +5,7 @@ description: A Model Context Protocol server that gives Claude Code 76 models, c
 
 # BlockRun MCP
 
-Give Claude Code access to 100 AI models, 83 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 100 AI models, 66 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 
@@ -266,7 +266,7 @@ blockrun_polymarket action:"buy" token_id:"<id>" amount_usd:5 order_type:"FOK" c
 
 #### `blockrun_surf`
 
-Unified crypto data — CEX data, on-chain SQL, labeled wallets, social mindshare, news, prediction markets, and unified search. See [Surf API reference](../api-reference/surf.md).
+Unified crypto data — CEX data, on-chain SQL, labeled wallets, news, prediction markets, and unified search. See [Surf API reference](../api-reference/surf.md).
 
 ```
 What's the BTC funding rate on Binance perps right now, and how does it compare to the 7-day average?

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -26,7 +26,7 @@ Every skill ships inside the [blockrun-mcp](https://github.com/BlockRunAI/blockr
 | `search` | Real-time web or news results with citations — "what just happened" questions. | `blockrun_search` |
 | `exa-research` | Researching products, papers, competitors, reading pages, cited answers. | `blockrun_exa` |
 | `crypto-data` | Any crypto data question — prices, FX, OHLC, DEX pairs, TVL, on-chain SQL, wallet labels. Says which of the five overlapping tools to use and which are free. | `blockrun_price` `blockrun_dex` `blockrun_defi` `blockrun_surf` `blockrun_rpc` |
-| `surf` | Deep crypto data — on-chain SQL, CEX order books, wallet net worth, social mindshare, news. | `blockrun_surf` |
+| `surf` | Deep crypto data — on-chain SQL, CEX order books, wallet net worth, prediction markets, news. | `blockrun_surf` |
 | `rpc` | Raw blockchain JSON-RPC — contract reads, balances, blocks, logs, gas — across 40 chains. | `blockrun_rpc` |
 | `prediction-markets` | Event probabilities, Polymarket / Kalshi odds, finding markets on a topic. | `blockrun_markets` |
 | `polymarket-trading` | Actually placing, managing, or redeeming real bets — setup, funding, confirm-gated orders. | `blockrun_polymarket` `blockrun_polymarket_read` |

--- a/docs/products/routing/clawrouter.md
+++ b/docs/products/routing/clawrouter.md
@@ -322,7 +322,7 @@ The same wallet pays for the rest of the gateway through the proxy. Prices as pu
 - **Image editing** — `/img2img --image ~/photo.png change the background to a starry sky`, with optional `--mask`.
 - **Video generation** — `/videogen a red apple slowly spinning` (`--model`, `--duration`), or `POST /v1/videos/generations`. Seedance 1.5 Pro / 2.0 Fast / 2.0 / 2.5, Sora 2, and Grok Imagine; the MP4 is downloaded to local disk so it survives the upstream's temporary bucket.
 - **Phone and voice** — `/cr-call +14155552671 "Confirm tomorrow's 3pm meeting"` places a real outbound AI voice call ($0.54 flat, up to 30 minutes); `clawrouter phone lookup|fraud|numbers ...` handles carrier lookup ($0.01), fraud signals ($0.05) and 30-day number leases ($5).
-- **Crypto data (Surf)** — `/v1/surf/*` is whitelisted through the proxy: 83 endpoints at a flat $0.0085 per call including the transaction fee, including ad-hoc on-chain SQL.
+- **Crypto data (Surf)** — `/v1/surf/*` is whitelisted through the proxy: 66 endpoints at a flat $0.0085 per call including the transaction fee, including ad-hoc on-chain SQL.
 
 ## Why ClawRouter?
 

--- a/docs/resources/ecosystem.md
+++ b/docs/resources/ecosystem.md
@@ -94,7 +94,7 @@ Projects, integrations, and partners building with BlockRun and x402. Every row 
 | **Sound Effects** | `/v1/audio/sound-effects` | $0.0535/generation | ✅ Live |
 | **Voice Calls** | `/v1/voice/call` | $0.541 flat | ✅ Live |
 | **Phone Numbers** | `/v1/phone/numbers/*` | $5.001/30 days | ✅ Live |
-| **Surf Crypto Data** | `/api/v1/surf/*` (83 endpoints) | $0.0085 | ✅ Live |
+| **Surf Crypto Data** | `/api/v1/surf/*` (66 endpoints) | $0.0085 | ✅ Live |
 | **Search** | `/v1/search` | $0.026/source | ✅ Live |
 | **Exa Web Search** | `/api/v1/exa/*` | $0.003–0.011 | ✅ Live |
 | **0x Swap (DEX)** | `/api/v1/zerox/*` | Free | ✅ Live |
@@ -178,7 +178,7 @@ BlockRun works with the x402 facilitator network:
 | [OKX OnchainOS](https://web3.okx.com) | Agentic wallet behind XClawRouter |
 | [Predexon](https://predexon.com) | Prediction market data |
 | [Modal](https://modal.com) | Sandbox compute (isolated code execution) |
-| [Surf (asksurf.ai)](https://asksurf.ai) | Crypto data — 83 endpoints (CEX, on-chain SQL, prediction markets, wallet labels, social, news) |
+| [Surf (asksurf.ai)](https://asksurf.ai) | Crypto data — 66 endpoints (CEX, on-chain SQL, prediction markets, wallet labels, news) |
 | [Bland.ai](https://bland.ai) | Conversational voice AI — outbound calls |
 | [Twilio](https://twilio.com) | Phone-number provisioning (wallet-owned US/CA numbers) |
 | [Exa](https://exa.ai) | Neural web search |

--- a/docs/x402/endpoints.md
+++ b/docs/x402/endpoints.md
@@ -124,7 +124,7 @@ Ephemeral, isolated Python sandboxes for agent code execution.
 
 | Method | Path | Purpose | Pricing |
 |---|---|---|---|
-| GET/POST | `/api/v1/surf/{path}` | Crypto market / on-chain intelligence — exchanges, on-chain analytics, wallet labels, social mindshare, news, search | Tier 1 $0.0085 (reads) · Tier 2 $0.0085 (AI rankings/trends) · Tier 3 $0.0085 (heavy LLM/SQL reports) |
+| GET/POST | `/api/v1/surf/{path}` | Crypto market / on-chain intelligence — exchanges, on-chain analytics, wallet labels, prediction markets, news, search | Tier 1 $0.0085 (reads) · Tier 2 $0.0085 (AI rankings/trends) · Tier 3 $0.0085 (heavy LLM/SQL reports) |
 
 ## 0x Swap (DEX)
 


### PR DESCRIPTION
Paired with BlockRunAI/blockrun#519, which removes 19 Surf routes the provider deleted (6 return `410 endpoint_removed`, 13 return `404` — the entire Social family).

Eight files still stated the old shape in the present tense. The registry change self-corrects every derived surface on the site, but not prose:

| file | was | now |
|---|---|---|
| `api-reference/surf.md` ×3 | 83 endpoints, 12 domains/categories, "social mindshare" | 66, 11, dropped |
| `api-reference/defillama.md` | "Exchange, on-chain and social data across 83 endpoints" | "Exchange and on-chain data across 66 endpoints" |
| `resources/ecosystem.md` ×2 | 83 endpoints, "social" in the domain list | 66, dropped |
| `products/routing/clawrouter.md` | 83 endpoints | 66 |
| `x402/endpoints.md` | "social mindshare" | "prediction markets" |
| `mcp/blockrun-mcp.md` ×2 | 83 endpoints, "social mindshare" | 66, dropped |
| `mcp/skills.md` | "social mindshare" | "prediction markets" |
| `getting-started/claude-code.md` | "social mindshare" | "prediction markets" |

`resources/changelog.md` keeps its 83 on purpose — a dated entry records what shipped that day.

**Land this before** the pointer bump in blockrun#519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017igmkDWurdiKJHkjhUyeDF