### PR TITLE
docs: Claude Sonnet 5 is $2/$10, in both tables on the page

### DIFF
--- a/docs/products/intelligence/pricing.md
+++ b/docs/products/intelligence/pricing.md
@@ -62,7 +62,7 @@ The free tier costs $0 — 5 reasoning, coding, and vision models with no per-to
 | Claude Opus 4.8 (previous flagship) | $5.00 | $25.00 |
 | Claude Opus 4.7 | $5.00 | $25.00 |
 | Claude Opus 4.5 | $5.00 | $25.00 |
-| Claude Sonnet 5 | $3.00 | $15.00 |
+| Claude Sonnet 5 | $2.00 | $10.00 |
 | Claude Sonnet 4.6 | $3.00 | $15.00 |
 | Claude Haiku 4.5 | $1.00 | $5.00 |
 
@@ -161,7 +161,7 @@ Other media: video from **$0.05/sec**, music **$0.15/track**, text-to-speech **$
 | Provider | Direct Pricing | BlockRun | Difference |
 |----------|---------------|----------|------------|
 | OpenAI GPT-5.4 | $2.50/$15.00 | $2.50/$15.00 | 0% + $0.001/request |
-| Anthropic Claude Sonnet 5 | $3.00/$15.00 | $3.00/$15.00 | 0% + $0.001/request |
+| Anthropic Claude Sonnet 5 | $2.00/$10.00 | $2.00/$10.00 | 0% + $0.001/request |
 | Anthropic Claude Sonnet 4.6 | $3.00/$15.00 | $3.00/$15.00 | 0% + $0.001/request |
 | DeepSeek V4 Flash Chat | $0.14/$0.28 | $0.14/$0.28 | 0% + $0.001/request |
 


### PR DESCRIPTION
Pairs with blockrun's Sonnet 5 correction. `$3.00/$15.00` → `$2.00/$10.00`, which is Anthropic's published rate and our actual cost on Bedrock's global profile.

**Two tables on this page, one guarded.** The rate table at line 65 is what blockrun's `published-price-sync.test.ts` reads. The Cost Comparison table at line 164 states the same price again — in *both* of its columns, under headers that assert 0% margin — and nothing checked it. It still said `$3.00/$15.00` on a page arguing we charge exactly what the provider charges.

blockrun now reads the two tables against each other (and asserts the comparison table's own 0% claim, that its two columns match), so neither can move without the other. No hardcoded number, so it survives the next reprice.

Based on the commit blockrun pins rather than main — main already has $2/$10 in the rate table from #83, but not the comparison table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wz3VoaMvGELcv7c8Wr9Re