### PR TITLE
chore(brand): refresh the snapshot to 102 / 78 chat / 6 free, and drop the delisted nemotron-3-nano-30b from five lists

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -102,7 +102,7 @@ BlockRun works with the x402 facilitator network:
 
 | Tool | Description | Install |
 |------|-------------|---------|
-| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP Server — <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools across <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> AI models, image/video/music/speech gen, voice calls, crypto data (Surf), prediction markets, DEX prices, raw JSON-RPC (<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains), DeFi TVL/yields, sandboxed code exec, search | `claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest` |
+| [blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) | MCP Server — <!-- br:mcp.tools -->19<!-- /br:mcp.tools --> tools across <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> AI models, image/video/music/speech gen, voice calls, crypto data (Surf), prediction markets, DEX prices, raw JSON-RPC (<!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains), DeFi TVL/yields, sandboxed code exec, search | `claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest` |
 | [blockrun-claude-plugin](https://github.com/BlockRunAI/blockrun-claude-plugin) | Media plugin — spend confirmation before each paid image/video/audio call, running cost meter, balance status line | `claude --plugin-dir /path/to/blockrun-plugin` |
 | [Claude-Code-GPT-IMAGE2-SeeDance-BlockRun](https://github.com/BlockRunAI/Claude-Code-GPT-IMAGE2-SeeDance-BlockRun) | `/headshot`, `/dance`, `/poster`, `/launch-film` — 848 prompt cases as one-line commands, pay per image | `curl -fsSL https://raw.githubusercontent.com/BlockRunAI/Claude-Code-GPT-IMAGE2-SeeDance-BlockRun/main/install.sh \| bash` |
 | [alpha-mcp](https://github.com/BlockRunAI/alpha-mcp) | AI crypto-trading MCP — technical analysis, sentiment, DEX swaps on Base, risk limits | `claude mcp add alpha npx @blockrun/alpha` |
@@ -201,7 +201,7 @@ BlockRun routes to these AI providers via x402:
 | Qwen | Qwen3.8 Flash (1M context, image input), Qwen3.7 Max (Alibaba flagship), Qwen3.7 Plus, Qwen3.7 Flash | $0.03–$1.48 / $0.13–$4.43 |
 | Tencent | Hy3 | $0.132 / $0.528 |
 | Xiaomi | MiMo-V2.5, MiMo-V2.5 Pro | $0.14–$0.435 / $0.28–$0.87 |
-| Free tier | Nemotron 3 Ultra 550B, Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision, Cohere North Mini Code, Poolside Laguna XS 2.1 (6 free models, keyless — no wallet needed) | **Free** |
+| Free tier | Nemotron 3 Ultra 550B, Nemotron 3.5 Lightning, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision, Cohere North Mini Code, Poolside Laguna XS 2.1 (6 free models, keyless — no wallet needed) | **Free** |
 
 ### Image Models
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Telegram](https://img.shields.io/badge/Telegram-Join-26A5E4)](https://t.me/+mroQv4-4hGgzOGUx)
 [![Research](https://img.shields.io/badge/Research-State%20of%20x402-orange)](./research/State_of_x402_2025.pdf)
 
-> **BlockRun** is the routing & payment layer for AI — one endpoint where AI agents autonomously discover, route, and pay for APIs using USDC via the x402 protocol. BlockRun provides pay-per-request access to <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> large language models (including GPT-5, Claude, Gemini, Grok, DeepSeek, and Kimi), image generation, neural web search (Exa), DEX data, trading signals, and prediction market data. Use one account API key or pay directly from a wallet with x402.
+> **BlockRun** is the routing & payment layer for AI — one endpoint where AI agents autonomously discover, route, and pay for APIs using USDC via the x402 protocol. BlockRun provides pay-per-request access to <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> large language models (including GPT-5, Claude, Gemini, Grok, DeepSeek, and Kimi), image generation, neural web search (Exa), DEX data, trading signals, and prediction market data. Use one account API key or pay directly from a wallet with x402.
 >
-> **For Claude Code users:** Add BlockRun in one command — access <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models, DEX data, trading signals, and more with account API billing or a Solana wallet.
+> **For Claude Code users:** Add BlockRun in one command — access <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models, DEX data, trading signals, and more with account API billing or a Solana wallet.
 > ```bash
 > claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 > ```
@@ -82,7 +82,7 @@ BlockRun is a unified API gateway — use account credits with one API key, or U
 
 | Product | Endpoint | Pricing | Description |
 |---------|----------|---------|-------------|
-| **LLM Chat** | `/v1/chat/completions` | Per token | OpenAI-compatible, <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models, streaming, tool calling |
+| **LLM Chat** | `/v1/chat/completions` | Per token | OpenAI-compatible, <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models, streaming, tool calling |
 | **Anthropic-Compat** | `/v1/messages` | Per token | Drop-in for Claude's Messages API |
 | **Image Generation** | `/v1/images/generations` | $0.015–0.15/image | GPT Image 1/2, Nano Banana / 2 / Pro, Grok Imagine / Pro, Seedream 5.0 Pro, CogView-4 |
 | **Image Editing** | `/v1/images/image2image` | Per request | AI-powered inpainting and image-to-image |
@@ -125,7 +125,7 @@ Real-time prediction market data powered by Predexon:
 
 ## Supported Models
 
-**<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models** across 11 providers — 5 of them free and keyless. All accessible through a single OpenAI-compatible API.
+**<!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models** across 11 providers — <!-- br:models.free -->6<!-- /br:models.free --> of them free and keyless. All accessible through a single OpenAI-compatible API.
 
 ### LLMs
 
@@ -141,7 +141,7 @@ Real-time prediction market data powered by Predexon:
 | **Qwen** | Qwen3.8 Flash (1M context, image input), Qwen3.7 Max (Alibaba flagship), Qwen3.7 Plus, Qwen3.7 Flash | $0.03–$1.48 / $0.13–$4.43 |
 | **Tencent** | Hy3 | $0.132 / $0.528 |
 | **Xiaomi** | MiMo-V2.5, MiMo-V2.5 Pro | $0.14–$0.435 / $0.28–$0.87 |
-| **Free tier** | Nemotron 3 Ultra 550B, Nemotron 3.5 Lightning, Nemotron 3 Nano 30B, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision, Cohere North Mini Code, Poolside Laguna XS 2.1 (6 free models, keyless — no wallet needed) | **Free** |
+| **Free tier** | Nemotron 3 Ultra 550B, Nemotron 3.5 Lightning, Nemotron 3 Nano Omni (vision), Llama 3.2 11B Vision, Cohere North Mini Code, Poolside Laguna XS 2.1 (6 free models, keyless — no wallet needed) | **Free** |
 
 ### Reasoning
 
@@ -178,7 +178,7 @@ Account API and wallet gateways have separate authentication and billing:
 |---------|---------|-------|--------|
 | **Account API** | `api.blockrun.ai/v1` | Account credits | ✅ Live |
 | **Solana** | `sol.blockrun.ai` | USDC | ✅ Live |
-| **Base** | `blockrun.ai` | USDC | ✅ Live (<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models) |
+| **Base** | `blockrun.ai` | USDC | ✅ Live (<!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models) |
 | **Polygon / Arbitrum / Optimism / Unichain** | `nano.blockrun.ai` | USDC via Circle Gateway (gas-free, batched) | ✅ Live |
 | **Base Sepolia** | `testnet.blockrun.ai` | USDC (testnet) | ✅ Testnet |
 
@@ -221,7 +221,7 @@ pip install blockrun-llm[solana]
 
 ### blockrun-mcp — Zero API Key Access for Claude Code Users
 
-**[blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp)** is the primary entry point for Claude Code developers. One command gives Claude access to <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models, real-time market data, image/video/music generation, AI voice calls, crypto data, and more — with account API billing or a wallet.
+**[blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp)** is the primary entry point for Claude Code developers. One command gives Claude access to <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models, real-time market data, image/video/music generation, AI voice calls, crypto data, and more — with account API billing or a wallet.
 
 ```bash
 claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
@@ -233,7 +233,7 @@ claude mcp add blockrun -s user -- npx -y @blockrun/mcp@latest
 
 | Tool | What it does |
 |------|-------------|
-| `blockrun_chat` | <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> AI models (GPT-5.5, Claude, Gemini, Grok, DeepSeek, Kimi, and more) |
+| `blockrun_chat` | <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> AI models (GPT-5.5, Claude, Gemini, Grok, DeepSeek, Kimi, and more) |
 | `blockrun_image` | Image generation — gpt-image-2, Nano Banana Pro, Grok Imagine, CogView-4 |
 | `blockrun_video` | Video generation — Sora 2, Seedance 2.0, Grok Imagine Video |
 | `blockrun_realface` | Enroll a real person (liveness) or AI character (Virtual Portrait) for Seedance video |
@@ -425,7 +425,7 @@ The **x402 protocol** (HTTP 402 "Payment Required") lets any HTTP request includ
 
 | Phase | Timeline | Focus |
 |-------|----------|-------|
-| LLM Gateway | Now | Pay-per-request access to <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> AI models |
+| LLM Gateway | Now | Pay-per-request access to <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> AI models |
 | Premium Data | Now | Neural web search (Exa), prediction markets (Predexon), Surf crypto data, DEX, image / video / music generation, voice calls |
 | Agent Wallets | Now | Per-agent delegation budgets (blockrun-mcp), Franklin agent wallet, spend confirmation plugins |
 | Multi-Chain | Now | Solana + Base gateways live; Polygon / Arbitrum / Optimism / Unichain via Circle Gateway (`nano.blockrun.ai`) |
@@ -467,7 +467,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 ## Frequently Asked Questions
 
 ### What is BlockRun?
-BlockRun is the routing & payment layer for AI — one endpoint where AI agents discover, route, and pay for APIs using USDC via the x402 protocol. It provides access to <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> LLMs, image generation, neural web search (Exa), and prediction market data without requiring API keys or subscriptions.
+BlockRun is the routing & payment layer for AI — one endpoint where AI agents discover, route, and pay for APIs using USDC via the x402 protocol. It provides access to <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> LLMs, image generation, neural web search (Exa), and prediction market data without requiring API keys or subscriptions.
 
 ### How do AI agents pay for APIs?
 With an API key, calls charge the BlockRun account. Register and manage credits in the account dashboard; no wallet is required.

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -2,17 +2,17 @@
   "$schema": "https://blockrun.ai/brand/numbers.schema.json",
   "version": 1,
   "models": {
-    "chatVisible": 76,
-    "totalVisible": 100,
-    "free": 7,
-    "freeWithheld": 26,
+    "chatVisible": 78,
+    "totalVisible": 102,
+    "free": 6,
+    "freeWithheld": 27,
     "image": 9,
     "video": 8,
     "music": 1,
     "speech": 5,
     "soundfx": 1,
-    "withFallback": 34,
-    "withFallbackAllEntries": 73
+    "withFallback": 33,
+    "withFallbackAllEntries": 74
   },
   "clawrouter": {
     "dimensions": 15,

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -244,7 +244,6 @@ Open-weight models served free of charge (no x402 payment), subject to a small p
 |----------|------|-------------|--------------|
 | `nvidia/nemotron-3-ultra-550b` | Nemotron 3 Ultra 550B (1M ctx) | **FREE** | **FREE** |
 | `nvidia/nemotron-3.5-lightning` | Nemotron 3.5 Lightning (1M ctx) | **FREE** | **FREE** |
-| `nvidia/nemotron-3-nano-30b` | Nemotron 3 Nano 30B | **FREE** | **FREE** |
 | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Nemotron 3 Nano Omni (vision) | **FREE** | **FREE** |
 | `nvidia/llama-3.2-11b-vision` | Llama 3.2 11B Vision | **FREE** | **FREE** |
 | `cohere/north-mini-code` | Cohere North Mini Code (coding) | **FREE** | **FREE** |

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -85,7 +85,7 @@ All BlockRun chat models are available. A sample of what the live catalog lists 
 | Google | gemini-3.1-pro, gemini-3.5-flash, gemini-3-flash-preview, gemini-2.5-flash-lite |
 | DeepSeek | deepseek-v4-pro, deepseek-chat, deepseek-reasoner |
 | xAI | grok-4.3, grok-4.5, grok-build-0.1 |
-| Free tier | nemotron-3-ultra-550b, nemotron-3.5-lightning, nemotron-3-nano-30b, north-mini-code |
+| Free tier | nemotron-3-ultra-550b, nemotron-3.5-lightning, north-mini-code |
 
 See [Models Reference](../api-reference/models.md) for the full list, or `curl https://blockrun.ai/api/v1/models`.
 

--- a/docs/sdks/xrpl.md
+++ b/docs/sdks/xrpl.md
@@ -399,7 +399,7 @@ The XRPL gateway mirrored the main BlockRun catalog (last catalog sync in the ga
 | **Google** | gemini-3.1-pro, gemini-3-flash-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite |
 | **xAI** | grok-4.3, grok-4.5, grok-build-0.1 |
 | **DeepSeek** | deepseek-chat, deepseek-reasoner, deepseek-v4-pro |
-| **FREE tier** | nemotron-3-ultra-550b, nemotron-3.5-lightning, nemotron-3-nano-30b, nemotron-3-nano-omni-30b-a3b-reasoning, llama-3.2-11b-vision, north-mini-code, laguna-xs-2.1 |
+| **FREE tier** | nemotron-3-ultra-550b, nemotron-3.5-lightning, nemotron-3-nano-omni-30b-a3b-reasoning, llama-3.2-11b-vision, north-mini-code, laguna-xs-2.1 |
 
 See [Intelligence Pricing](../products/intelligence/pricing.md) for full pricing details.
 


### PR DESCRIPTION
The committed snapshot was two catalog moves behind the published artifact
(76/100/7 → 78/102/6), so every marker here rendered stale numbers; #82 only
caught the mcp.tools 20 → 19 part. Regenerated with --refresh, no hand-edited
digits inside markers.

Outside the markers, five hand-typed lists still named nvidia/nemotron-3-nano-30b,
delisted in blockrun#537 today (README, ECOSYSTEM, docs/api-reference/models.md,
docs/frameworks/elizaos.md, docs/sdks/xrpl.md), and README's "5 of them free"
literal is now a br:models.free marker so it moves with the catalog.

Supersedes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ6wG4k5TgeUgYneCMz1oc