### PR TITLE
docs: grok-imagine-image-pro still quoted the pre-correction price on two pages

### DIFF
--- a/docs/api-reference/image-generation.md
+++ b/docs/api-reference/image-generation.md
@@ -56,7 +56,7 @@ Prices are what the `402` challenge quotes and what is billed for **one** image 
 | `google/nano-banana-pro` | Google | 1024x1024, 2048x2048, 4096x4096 | $0.106 / $0.106 / $0.1585 |
 | `zai/cogview-4` | Zhipu AI | 512x512 – 1440x1440 | $0.01675 / $0.022 |
 | `xai/grok-imagine-image` | xAI | 1024x1024 | $0.022 |
-| `xai/grok-imagine-image-pro` | xAI | 1024x1024 | $0.0745 |
+| `xai/grok-imagine-image-pro` | xAI | 1024x1024 | $0.0535 |
 | `bytedance/seedream-5-pro` | ByteDance | 1024x1024 – 2848x1600 (8 sizes) | $0.04825 / $0.0955 |
 
 `GET /api/v1/images/models` returns the same catalog with `pricing.sizes[]` per model (catalog rates, before margin and fee). `openai/dall-e-3` was removed from the catalog and now returns the unknown-model `400`.

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -261,7 +261,7 @@ Media prices below include the 5% media margin; the flat $0.001 transaction fee 
 | `google/nano-banana-2` | Nano Banana 2 | $0.0945/image |
 | `google/nano-banana-pro` | Nano Banana Pro | $0.105-0.1575/image |
 | `xai/grok-imagine-image` | Grok Imagine | $0.021/image |
-| `xai/grok-imagine-image-pro` | Grok Imagine Pro | $0.0735/image |
+| `xai/grok-imagine-image-pro` | Grok Imagine Pro | $0.0525/image |
 | `zai/cogview-4` | CogView-4 | $0.01575-0.021/image |
 | `bytedance/seedream-5-pro` | Seedream 5.0 Pro | $0.047-0.095/image (async, ~2 min) |
 


### PR DESCRIPTION
The gateway corrected this SKU's 1K size row from $0.07 to the $0.05 it
advertises (blockrun#543, live since 2026-09-08). The catalogue moved; these two
pages did not, so both kept quoting the old number — 39% and 40% over what a
caller is now charged.

  api-reference/models.md:264            $0.0735 -> $0.0525
  api-reference/image-generation.md:59   $0.0745 -> $0.0535

The two figures differ because the two pages use different conventions, and each
is internally consistent, so each was moved on its own terms rather than
unified: models.md lists margin only (google/nano-banana, same $0.05 catalogue
price, is $0.0525 there) and image-generation.md lists margin plus the $0.001
transaction fee ($0.0535 for the same model). Both now agree with nano-banana on
their own page, which is the check that matters — same catalogue price, same
published number.

resources/changelog.md's $0.07 is left alone: it is a dated record of what the
price was, not a claim about what it is.

Found by the blockrun-sol session reading the published surfaces by hand after
porting the fix. The reason no test caught it is being addressed on the gateway
side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ6wG4k5TgeUgYneCMz1oc