### PR TITLE
docs: add grok-imagine-image-2.0, and the catalog is 103 models

### DIFF
--- a/docs/api-reference/image-generation.md
+++ b/docs/api-reference/image-generation.md
@@ -56,6 +56,7 @@ Prices are what the `402` challenge quotes and what is billed for **one** image 
 | `google/nano-banana-pro` | Google | 1024x1024, 2048x2048, 4096x4096 | $0.106 / $0.106 / $0.1585 |
 | `zai/cogview-4` | Zhipu AI | 512x512 – 1440x1440 | $0.01675 / $0.022 |
 | `xai/grok-imagine-image` | xAI | 1024x1024 | $0.022 |
+| `xai/grok-imagine-image-2.0` | xAI | 1024x1024 | $0.043 |
 | `xai/grok-imagine-image-pro` | xAI | 1024x1024 | $0.0535 |
 | `bytedance/seedream-5-pro` | ByteDance | 1024x1024 – 2848x1600 (8 sizes) | $0.04825 / $0.0955 |
 

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -261,6 +261,7 @@ Media prices below include the 5% media margin; the flat $0.001 transaction fee 
 | `google/nano-banana-2` | Nano Banana 2 | $0.0945/image |
 | `google/nano-banana-pro` | Nano Banana Pro | $0.105-0.1575/image |
 | `xai/grok-imagine-image` | Grok Imagine | $0.021/image |
+| `xai/grok-imagine-image-2.0` | Grok Imagine 2.0 | $0.042/image |
 | `xai/grok-imagine-image-pro` | Grok Imagine Pro | $0.0525/image |
 | `zai/cogview-4` | CogView-4 | $0.01575-0.021/image |
 | `bytedance/seedream-5-pro` | Seedream 5.0 Pro | $0.047-0.095/image (async, ~2 min) |

--- a/docs/frameworks/agentkit.md
+++ b/docs/frameworks/agentkit.md
@@ -1,6 +1,6 @@
 ---
 title: AgentKit Integration
-description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 102 AI models.
+description: Pair Coinbase AgentKit with BlockRun so your agents both hold on-chain assets and pay per request for 103 AI models.
 ---
 
 # AgentKit Integration

--- a/docs/frameworks/elizaos.md
+++ b/docs/frameworks/elizaos.md
@@ -1,6 +1,6 @@
 ---
 title: ElizaOS Integration
-description: Add the BlockRun plugin to ElizaOS so your agents reach 102 AI models via x402 micropayments — no per-provider API keys.
+description: Add the BlockRun plugin to ElizaOS so your agents reach 103 AI models via x402 micropayments — no per-provider API keys.
 ---
 
 # ElizaOS Integration
@@ -11,7 +11,7 @@ Use BlockRun as an LLM provider in ElizaOS agents — one plugin unlocks 78 mode
 BlockRun's primary paths are [Franklin](../products/franklin.md), the [BlockRun MCP](../mcp/blockrun-mcp.md), and the [SDKs](../sdks/python.md). Framework integrations like this one are community-maintained.
 :::
 
-[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 102 AI models via x402 micropayments.
+[ElizaOS](https://github.com/elizaOS/eliza) is an open-source agent framework. The BlockRun plugin gives your ElizaOS agents access to 103 AI models via x402 micropayments.
 
 ## Setup
 

--- a/docs/frameworks/goat.md
+++ b/docs/frameworks/goat.md
@@ -1,6 +1,6 @@
 ---
 title: GOAT SDK Integration
-description: Combine GOAT SDK's cross-chain execution with BlockRun's 102 AI models, paid per request over x402 — until the official plugin ships.
+description: Combine GOAT SDK's cross-chain execution with BlockRun's 103 AI models, paid per request over x402 — until the official plugin ships.
 ---
 
 # GOAT SDK Integration

--- a/docs/mcp/blockrun-mcp.md
+++ b/docs/mcp/blockrun-mcp.md
@@ -5,7 +5,7 @@ description: A Model Context Protocol server that gives Claude Code 78 models, c
 
 # BlockRun MCP
 
-Give Claude Code access to 102 AI models, 66 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
+Give Claude Code access to 103 AI models, 66 crypto data endpoints, voice calls, image/video/music generation, prediction markets (read *and* trade), multi-chain RPC, and a sandbox runtime — all with zero API keys.
 
 BlockRun MCP is a Model Context Protocol server that connects Claude Code to BlockRun's intelligence, trading, and creation capabilities.
 

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -1,11 +1,11 @@
 ---
 title: Go SDK
-description: The Go SDK for BlockRun — call 102 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
+description: The Go SDK for BlockRun — call 103 AI models, generate images, video, music and speech, search the web, read market data and multi-chain RPC, and manage wallets over x402 micropayments with no API keys.
 ---
 
 # Go SDK
 
-The Go SDK for BlockRun provides access to 102 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
+The Go SDK for BlockRun provides access to 103 AI models via x402 micropayments — pay per call in USDC on **Base** or **Solana**, no API keys. Beyond chat it covers image, video, music and speech generation, web search, market data, prediction markets, DeFi and DEX data, and multi-chain JSON-RPC.
 
 **Source:** [github.com/BlockRunAI/blockrun-llm-go](https://github.com/BlockRunAI/blockrun-llm-go) · `go get github.com/BlockRunAI/blockrun-llm-go@v0.20.0` · Go 1.22+ · MIT
 


### PR DESCRIPTION
xAI's grok-imagine-image-2.0 is now sold through the gateway at $0.04/image
upstream. It sits between Grok Imagine ($0.02) and the Pro quality tier ($0.05).

  api-reference/models.md            $0.042/image  (margin only, this page's convention)
  api-reference/image-generation.md  $0.043        (margin + the $0.001 fee)

Both figures were read out of the catalog rather than typed: `calculateImagePrice`
gives 0.042 and `cheapestImagePrice` (which adds the fee) gives 0.043.

Model count 102 -> 103 in the five pages that state it: sdks/go.md (×2),
mcp/blockrun-mcp.md, frameworks/{elizaos,goat,agentkit}.md.

One `102` is deliberately left alone: `api-reference/video-generation.md:158`
contains `$2.102`, which is a price, not a count. A blind number sweep would
have changed it — this is why the count guard matches the claim vocabulary
around a number rather than the digits on their own.

Why 2.0 is worth listing now rather than in November: on 2026-11-02 xAI retires
grok-imagine-image-quality, which is what our Pro SKU maps to upstream, and
serves those requests from 2.0 at quality "low" with no change to the request or
response shape. Nothing breaks and nothing alerts. Listing 2.0 explicitly gives
callers the choice before that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ6wG4k5TgeUgYneCMz1oc