### PR TITLE
docs(errors): the debug field is redacted, not raw upstream text

### DIFF
--- a/docs/api-reference/errors.md
+++ b/docs/api-reference/errors.md
@@ -21,7 +21,7 @@ BlockRun uses standard HTTP status codes and returns detailed error information.
 
 ## Error Response Format
 
-Gateway errors use the OpenAI envelope, with `message` and `code` mirrored at the top level for older clients. `debug` carries the raw upstream text when there is one.
+Gateway errors use the OpenAI envelope, with `message` and `code` mirrored at the top level for older clients. `debug` carries the upstream text when there is one, **redacted**: credentials, URLs and any routing infrastructure we do not sell under its own name are removed before the response is sent. The status code and the upstream's own description of the fault survive, so `debug` stays useful for a bug report — it is just not a verbatim copy.
 
 ```json
 {
@@ -33,7 +33,7 @@ Gateway errors use the OpenAI envelope, with `message` and `code` mirrored at th
   },
   "message": "Message @bc1max on Telegram for help.",
   "code": "INVALID_PARAMETER",
-  "debug": "<upstream error text>"
+  "debug": "<upstream error text, redacted>"
 }
 ```
 


### PR DESCRIPTION
The doc promised `debug` "carries the raw upstream text". Raw was the bug.

Reproduced unauthenticated against production on 2026-09-10:

```
POST /v1/chat/completions  {"model":"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning", …}
→ "debug": "404 No endpoints found … visit: https://openrouter.ai/docs/guides/routing/provider-selection"
```

That model's `owned_by` is deliberately rewritten away from the conduit. The debug string undid it in the same response.

Gateway fix in BlockRunAI/blockrun. This just makes the documented contract match: credentials, URLs and routing infrastructure are stripped; the status code and the upstream's description of the fault survive, so the field still supports a bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ6wG4k5TgeUgYneCMz1oc